### PR TITLE
New "Action" module

### DIFF
--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -1,0 +1,408 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file //
+// if one is included with the Software (each a “Larger Work” to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// #![warn(missing_docs)]
+
+use std::clone::Clone;
+use std::fmt;
+
+use ast::{Arena, ArenaError, ArenaResult, NodeId};
+
+/// Apply an action to an AST node.
+pub trait ApplyAction<T: Clone, U: Clone> {
+    fn apply(&mut self, arena: &mut Arena<T, U>) -> ArenaResult;
+}
+
+/// A list of actions to be applied.
+///
+/// This type will usually be used by iterating over the list and calling
+/// `apply()` on each element.
+pub type ActionList<T, U> = Vec<Box<ApplyAction<T, U>>>;
+
+/// Delete a node from a given AST.
+pub struct Delete {
+    node: NodeId,
+}
+
+/// Insert a new node into an AST as the `position`th child of an existing node.
+pub struct Insert<T: Clone, U: Clone> {
+    nth_child: u16,
+    data: T,
+    ty: U,
+    indent: u32,
+    new_parent: NodeId,
+}
+
+/// Move a node from one place to another within an AST.
+pub struct Move {
+    from_node: NodeId,
+    parent: NodeId,
+    pos: u16,
+}
+
+/// Update the data inside an AST node.
+pub struct Update<T: Clone, U: Clone> {
+    node: NodeId,
+    value: T,
+    ty: U,
+}
+
+impl fmt::Display for Delete {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "DEL {}", self.node)
+    }
+}
+
+impl<T: fmt::Display + Clone, U: fmt::Display + Clone> fmt::Display for Insert<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let indent = " ".repeat(self.indent as usize);
+        write!(f,
+               "INS {}{} {} to {} at {}",
+               indent,
+               self.ty,
+               self.data,
+               self.new_parent,
+               self.nth_child)
+    }
+}
+
+impl fmt::Display for Move {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f,
+               "MOV {} to {} at {}",
+               self.from_node,
+               self.parent,
+               self.pos)
+    }
+}
+
+impl<T: fmt::Display + Clone, U: fmt::Display + Clone> fmt::Display for Update<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "UPD {} to {} {}", self.node, self.ty, self.value)
+    }
+}
+
+impl<T: Clone, U: Clone> ApplyAction<T, U> for Delete {
+    fn apply(&mut self, arena: &mut Arena<T, U>) -> ArenaResult {
+        self.node.detach_with_children(arena)
+    }
+}
+
+impl<T: Clone, U: Clone> ApplyAction<T, U> for Insert<T, U> {
+    fn apply(&mut self, arena: &mut Arena<T, U>) -> ArenaResult {
+        let mut new_id = arena.new_node(self.data.clone(), self.ty.clone(), self.indent);
+        new_id.make_nth_child_of(self.new_parent, self.nth_child, arena)
+    }
+}
+
+impl<T: Clone, U: Clone> ApplyAction<T, U> for Move {
+    fn apply(&mut self, arena: &mut Arena<T, U>) -> ArenaResult {
+        self.from_node
+            .make_nth_child_of(self.parent, self.pos, arena)
+    }
+}
+
+impl<T: Clone, U: Clone> ApplyAction<T, U> for Update<T, U> {
+    fn apply(&mut self, arena: &mut Arena<T, U>) -> ArenaResult {
+        if !arena.contains(self.node) {
+            return Err(ArenaError::NodeIdNotFound);
+        }
+        arena[self.node].data = self.value.clone();
+        arena[self.node].ty = self.ty.clone();
+        Ok(())
+    }
+}
+
+impl<T: Clone, U: Clone> ApplyAction<T, U> for ActionList<T, U> {
+    fn apply(&mut self, arena: &mut Arena<T, U>) -> ArenaResult {
+        // Iterating over indices here avoids having two mutable borrows.
+        for index in 0..self.len() {
+            self[index].apply(arena)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn create_arena() -> Arena<String, String> {
+        let mut arena = Arena::new();
+        let root = arena.new_node(String::from("+"), String::from("Expr"), 0);
+        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2);
+        arena.make_child_of(n1, root).unwrap();
+        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2);
+        arena.make_child_of(n2, root).unwrap();
+        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4);
+        arena.make_child_of(n3, n2).unwrap();
+        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4);
+        arena.make_child_of(n4, n2).unwrap();
+        arena
+    }
+
+    #[test]
+    fn fmt_delete() {
+        let del = Delete { node: NodeId::new(2) };
+        assert_eq!("DEL 2", format!("{:}", del));
+    }
+
+    #[test]
+    fn fmt_insert() {
+        let ins = Insert {
+            data: "100",
+            ty: "INT",
+            indent: 4,
+            new_parent: NodeId::new(2),
+            nth_child: 0,
+        };
+        assert_eq!("INS     INT 100 to 2 at 0", format!("{:}", ins));
+    }
+
+    #[test]
+    fn fmt_move() {
+        let mov = Move {
+            from_node: NodeId::new(3),
+            parent: NodeId::new(2),
+            pos: 0,
+        };
+        assert_eq!("MOV 3 to 2 at 0", format!("{:}", mov));
+    }
+
+    #[test]
+    fn fmt_update() {
+        let upd = Update {
+            node: NodeId::new(4),
+            value: String::from("100"),
+            ty: String::from("INT"),
+        };
+        assert_eq!("UPD 4 to INT 100", format!("{:}", upd));
+    }
+
+    #[test]
+    fn apply_delete() {
+        let mut arena = create_arena();
+        let format1 = "Expr +
+  INT 1
+  Expr *
+    INT 3
+    INT 4
+";
+        assert_eq!(format1, format!("{}", arena));
+        let mut del = Delete { node: NodeId::new(2) };
+        del.apply(&mut arena).unwrap();
+        let format2 = "Expr +
+  INT 1
+";
+        assert_eq!(format2, format!("{}", arena));
+    }
+
+    #[test]
+    fn apply_insert() {
+        let mut arena = create_arena();
+        let format1 = "Expr +
+  INT 1
+  Expr *
+    INT 3
+    INT 4
+";
+        assert_eq!(format1, format!("{}", arena));
+        let mut ins = Insert {
+            nth_child: 0,
+            data: String::from("100"),
+            ty: String::from("INT"),
+            indent: 4,
+            new_parent: NodeId::new(2),
+        };
+        ins.apply(&mut arena).unwrap();
+        let format2 = "Expr +
+  INT 1
+  Expr *
+    INT 100
+    INT 3
+    INT 4
+";
+        assert_eq!(format2, format!("{}", arena));
+    }
+
+    #[test]
+    fn apply_move() {
+        let mut arena = create_arena();
+        let format1 = "Expr +
+  INT 1
+  Expr *
+    INT 3
+    INT 4
+";
+        assert_eq!(format1, format!("{}", arena));
+        let mut mov = Move {
+            from_node: NodeId::new(4),
+            parent: NodeId::new(2),
+            pos: 0,
+        };
+        mov.apply(&mut arena).unwrap();
+        let format2 = "Expr +
+  INT 1
+  Expr *
+    INT 4
+    INT 3
+";
+        assert_eq!(format2, format!("{}", arena));
+    }
+
+    #[test]
+    fn apply_update() {
+        let mut arena = create_arena();
+        assert_eq!(5, arena.size());
+        let format1 = "Expr +
+  INT 1
+  Expr *
+    INT 3
+    INT 4
+";
+        assert_eq!(format1, format!("{}", arena));
+        let mut upd = Update {
+            node: NodeId::new(2),
+            value: String::from("+"),
+            ty: String::from("Expr"),
+        };
+        upd.apply(&mut arena).unwrap();
+        let format2 = "Expr +
+  INT 1
+  Expr +
+    INT 3
+    INT 4
+";
+        assert_eq!(format2, format!("{}", arena));
+    }
+
+    #[test]
+    fn apply_to_list1() {
+        let mut arena = create_arena();
+        let format1 = "Expr +
+  INT 1
+  Expr *
+    INT 3
+    INT 4
+";
+        assert_eq!(format1, format!("{}", arena));
+        // Create action list.
+        let mut actions: ActionList<String, String> = vec![];
+        let del1 = Delete { node: NodeId::new(3) }; // INT 3
+        let del2 = Delete { node: NodeId::new(4) }; // INT 4
+        let ins1 = Insert {
+            data: String::from("100"),
+            ty: String::from("INT"),
+            indent: 4,
+            new_parent: NodeId::new(2),
+            nth_child: 0,
+        };
+        let ins2 = Insert {
+            data: String::from("99"),
+            ty: String::from("INT"),
+            indent: 4,
+            new_parent: NodeId::new(2),
+            nth_child: 1,
+        };
+        let mov = Move {
+            // Swap "INT 100" and "INT 99".
+            from_node: NodeId::new(6),
+            parent: NodeId::new(2),
+            pos: 0,
+        };
+        let upd = Update {
+            // Change "+"" to "*".
+            node: NodeId::new(0),
+            value: String::from("*"),
+            ty: String::from("Expr"),
+        };
+        actions.push(Box::new(del1));
+        actions.push(Box::new(del2));
+        actions.push(Box::new(ins1));
+        actions.push(Box::new(ins2));
+        actions.push(Box::new(mov));
+        actions.push(Box::new(upd));
+        // Apply action list.
+        actions.apply(&mut arena).unwrap();
+        let format2 = "Expr *
+  INT 1
+  Expr *
+    INT 99
+    INT 100
+";
+        assert_eq!(format2, format!("{}", arena));
+    }
+
+    #[test]
+    fn apply_to_list2() {
+        let mut arena = create_arena();
+        let format1 = "Expr +
+  INT 1
+  Expr *
+    INT 3
+    INT 4
+";
+        assert_eq!(format1, format!("{}", arena));
+        // Create action list.
+        let mut actions: ActionList<String, String> = vec![];
+        let del = Delete { node: NodeId::new(2) }; // Remove "Expr *".
+        let ins = Insert {
+            data: String::from("2"),
+            ty: String::from("INT"),
+            indent: 2,
+            new_parent: NodeId::new(0),
+            nth_child: 1,
+        };
+        let upd = Update {
+            // Change "+" to "*".
+            node: NodeId::new(0),
+            value: String::from("*"),
+            ty: String::from("Expr"),
+        };
+        actions.push(Box::new(del));
+        actions.push(Box::new(ins));
+        actions.push(Box::new(upd));
+        // Apply action list.
+        actions.apply(&mut arena).unwrap();
+        let format2 = "Expr *
+  INT 1
+  INT 2
+";
+        assert_eq!(format2, format!("{}", arena));
+    }
+
+}

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -531,230 +531,250 @@ pub fn parse_file(input_path: &str) -> Result<Arena<String, String>, ParseError>
 }
 
 #[cfg(test)]
-#[test]
-fn new_ast_node() {
-    let arena = &mut Arena::new();
-    assert!(arena.is_empty());
-    let n0 = arena.new_node("100", "INT", 8);
-    assert!(arena[n0].index != None);
-    assert_eq!(n0, arena[n0].index.unwrap());
-    assert!(!arena.is_empty());
-    let n1 = arena.new_node("foobar", "STR", 12);
-    assert!(arena[n1].index != None);
-    assert_eq!(n1, arena[n1].index.unwrap());
-    assert!(!arena.is_empty());
-    // Check node ids, data, types and indent levels.
-    assert_eq!(0, n0.index);
-    assert_eq!("100", arena[n0].data);
-    assert_eq!("INT", arena[n0].ty);
-    assert_eq!(8, arena[n0].indent);
-    assert_eq!(1, n1.index);
-    assert_eq!("foobar", arena[n1].data);
-    assert_eq!("STR", arena[n1].ty);
-    assert_eq!(12, arena[n1].indent);
-}
+mod tests {
+    use super::*;
 
-#[test]
-fn make_child_of_1() {
-    let arena = &mut Arena::new();
-    assert!(arena.is_empty());
-    let root = arena.new_node("+", "Expr", 0);
-    let n1 = arena.new_node("1", "INT", 4);
-    arena.make_child_of(n1, root).unwrap();
-    let n2 = arena.new_node("*", "Expr", 4);
-    arena.make_child_of(n2, root).unwrap();
-    let n3 = arena.new_node("3", "INT", 8);
-    arena.make_child_of(n3, n2).unwrap();
-    let n4 = arena.new_node("4", "INT", 8);
-    arena.make_child_of(n4, n2).unwrap();
-    assert!(!arena.is_empty());
-    // Check indices.
-    assert_eq!(root, arena[root].index.unwrap());
-    assert_eq!(n1, arena[n1].index.unwrap());
-    assert_eq!(n2, arena[n2].index.unwrap());
-    assert_eq!(n3, arena[n3].index.unwrap());
-    assert_eq!(n4, arena[n4].index.unwrap());
-    // Check roots and leaves.
-    assert!(arena[root].is_root());
-    assert!(!arena[n1].is_root());
-    assert!(!arena[n2].is_root());
-    assert!(!arena[n3].is_root());
-    assert!(!arena[n4].is_root());
-    assert!(!arena[root].is_leaf());
-    assert!(arena[n1].is_leaf());
-    assert!(!arena[n2].is_leaf());
-    assert!(arena[n3].is_leaf());
-    assert!(arena[n4].is_leaf());
-}
+    #[test]
+    fn new_ast_node() {
+        let arena = &mut Arena::new();
+        assert!(arena.is_empty());
+        let n0 = arena.new_node("100", "INT", 8);
+        assert!(arena[n0].index != None);
+        assert_eq!(n0, arena[n0].index.unwrap());
+        assert!(!arena.is_empty());
+        let n1 = arena.new_node("foobar", "STR", 12);
+        assert!(arena[n1].index != None);
+        assert_eq!(n1, arena[n1].index.unwrap());
+        assert!(!arena.is_empty());
+        // Check node ids, data, types and indent levels.
+        assert_eq!(0, n0.index);
+        assert_eq!("100", arena[n0].data);
+        assert_eq!("INT", arena[n0].ty);
+        assert_eq!(8, arena[n0].indent);
+        assert_eq!(1, n1.index);
+        assert_eq!("foobar", arena[n1].data);
+        assert_eq!("STR", arena[n1].ty);
+        assert_eq!(12, arena[n1].indent);
+    }
 
-#[test]
-fn make_child_of_2() {
-    let arena = &mut Arena::new();
-    assert!(arena.is_empty());
-    let root = arena.new_node("+", "Expr", 4);
-    assert!(!arena.is_empty());
-    let n1 = arena.new_node("1", "INT", 0);
-    assert!(!arena.is_empty());
-    arena.make_child_of(n1, root).unwrap();
-    let n2 = arena.new_node("2", "INT", 0);
-    assert!(!arena.is_empty());
-    arena.make_child_of(n2, root).unwrap();
-    // Check indices.
-    assert_eq!(root, arena[root].index.unwrap());
-    assert_eq!(n1, arena[n1].index.unwrap());
-    assert_eq!(n2, arena[n2].index.unwrap());
-    // Check parents correctly set.
-    assert_eq!(None, arena[root].parent);
-    assert_eq!(root, arena[n1].parent.unwrap());
-    assert_eq!(root, arena[n2].parent.unwrap());
-    // Check children correctly set.
-    assert_eq!(n1, arena[root].first_child.unwrap());
-    assert_eq!(n2, arena[root].last_child.unwrap());
-    assert_eq!(None, arena[n1].first_child);
-    assert_eq!(None, arena[n1].last_child);
-    assert_eq!(None, arena[n2].first_child);
-    assert_eq!(None, arena[n2].last_child);
-    // Check siblings correctly set.
-    assert_eq!(n1, arena[n2].previous_sibling.unwrap());
-    assert_eq!(None, arena[n2].next_sibling);
-    assert_eq!(None, arena[n1].previous_sibling);
-    assert_eq!(n2, arena[n1].next_sibling.unwrap());
-    assert_eq!(None, arena[root].previous_sibling);
-    assert_eq!(None, arena[root].next_sibling);
-}
+    #[test]
+    fn make_child_of_1() {
+        let arena = &mut Arena::new();
+        assert!(arena.is_empty());
+        let root = arena.new_node("+", "Expr", 0);
+        let n1 = arena.new_node("1", "INT", 4);
+        arena.make_child_of(n1, root).unwrap();
+        let n2 = arena.new_node("*", "Expr", 4);
+        arena.make_child_of(n2, root).unwrap();
+        let n3 = arena.new_node("3", "INT", 8);
+        arena.make_child_of(n3, n2).unwrap();
+        let n4 = arena.new_node("4", "INT", 8);
+        arena.make_child_of(n4, n2).unwrap();
+        assert!(!arena.is_empty());
+        // Check indices.
+        assert_eq!(root, arena[root].index.unwrap());
+        assert_eq!(n1, arena[n1].index.unwrap());
+        assert_eq!(n2, arena[n2].index.unwrap());
+        assert_eq!(n3, arena[n3].index.unwrap());
+        assert_eq!(n4, arena[n4].index.unwrap());
+        // Check roots and leaves.
+        assert!(arena[root].is_root());
+        assert!(!arena[n1].is_root());
+        assert!(!arena[n2].is_root());
+        assert!(!arena[n3].is_root());
+        assert!(!arena[n4].is_root());
+        assert!(!arena[root].is_leaf());
+        assert!(arena[n1].is_leaf());
+        assert!(!arena[n2].is_leaf());
+        assert!(arena[n3].is_leaf());
+        assert!(arena[n4].is_leaf());
+    }
 
-#[test]
-fn node_fmt() {
-    let node = Node::new("private", "MODIFIER", 4);
-    let expected = "    MODIFIER private";
-    assert_eq!(expected, format!("{:}", node));
-}
+    #[test]
+    fn make_child_of_2() {
+        let arena = &mut Arena::new();
+        assert!(arena.is_empty());
+        let root = arena.new_node("+", "Expr", 4);
+        assert!(!arena.is_empty());
+        let n1 = arena.new_node("1", "INT", 0);
+        assert!(!arena.is_empty());
+        arena.make_child_of(n1, root).unwrap();
+        let n2 = arena.new_node("2", "INT", 0);
+        assert!(!arena.is_empty());
+        arena.make_child_of(n2, root).unwrap();
+        // Check indices.
+        assert_eq!(root, arena[root].index.unwrap());
+        assert_eq!(n1, arena[n1].index.unwrap());
+        assert_eq!(n2, arena[n2].index.unwrap());
+        // Check parents correctly set.
+        assert_eq!(None, arena[root].parent);
+        assert_eq!(root, arena[n1].parent.unwrap());
+        assert_eq!(root, arena[n2].parent.unwrap());
+        // Check children correctly set.
+        assert_eq!(n1, arena[root].first_child.unwrap());
+        assert_eq!(n2, arena[root].last_child.unwrap());
+        assert_eq!(None, arena[n1].first_child);
+        assert_eq!(None, arena[n1].last_child);
+        assert_eq!(None, arena[n2].first_child);
+        assert_eq!(None, arena[n2].last_child);
+        // Check siblings correctly set.
+        assert_eq!(n1, arena[n2].previous_sibling.unwrap());
+        assert_eq!(None, arena[n2].next_sibling);
+        assert_eq!(None, arena[n1].previous_sibling);
+        assert_eq!(n2, arena[n1].next_sibling.unwrap());
+        assert_eq!(None, arena[root].previous_sibling);
+        assert_eq!(None, arena[root].next_sibling);
+    }
 
-#[test]
-fn arena_fmt() {
-    let arena = &mut Arena::new();
-    let root = arena.new_node("+", "Expr", 4);
-    let n1 = arena.new_node("1", "INT", 0);
-    arena.make_child_of(n1, root).unwrap();
-    let n2 = arena.new_node("2", "INT", 0);
-    arena.make_child_of(n2, root).unwrap();
-    let expected = "    Expr +
+    #[test]
+    fn node_fmt() {
+        let node = Node::new("private", "MODIFIER", 4);
+        let expected = "    MODIFIER private";
+        assert_eq!(expected, format!("{:}", node));
+    }
+
+    #[test]
+    fn arena_fmt() {
+        let arena = &mut Arena::new();
+        let root = arena.new_node("+", "Expr", 4);
+        let n1 = arena.new_node("1", "INT", 0);
+        arena.make_child_of(n1, root).unwrap();
+        let n2 = arena.new_node("2", "INT", 0);
+        arena.make_child_of(n2, root).unwrap();
+        let expected = "    Expr +
 INT 1
 INT 2
 ";
-    assert_eq!(expected, format!("{:}", arena));
-}
-
-#[test]
-fn get_edges_1() {
-    let arena: Arena<String, String> = Arena::new();
-    assert!(arena.is_empty());
-    let edges: Vec<EdgeId> = vec![];
-    assert_eq!(edges, arena.get_edges());
-}
-
-#[test]
-fn get_edges_2() {
-    let arena = &mut Arena::new();
-    arena.new_node("1", "INT", 0);
-    let edges: Vec<EdgeId> = vec![];
-    assert_eq!(edges, arena.get_edges());
-}
-
-#[test]
-fn get_edges_3() {
-    let arena = &mut Arena::new();
-    let root = arena.new_node("+", "Expr", 0);
-    let n1 = arena.new_node("1", "INT", 4);
-    arena.make_child_of(n1, root).unwrap();
-    let n2 = arena.new_node("*", "Expr", 4);
-    arena.make_child_of(n2, root).unwrap();
-    let n3 = arena.new_node("3", "INT", 8);
-    arena.make_child_of(n3, n2).unwrap();
-    let n4 = arena.new_node("4", "INT", 8);
-    arena.make_child_of(n4, n2).unwrap();
-    let edges: Vec<EdgeId> = vec![(NodeId::new(0), NodeId::new(1)),
-                                  (NodeId::new(0), NodeId::new(2)),
-                                  (NodeId::new(2), NodeId::new(3)),
-                                  (NodeId::new(2), NodeId::new(4))];
-    assert_eq!(edges, arena.get_edges());
-}
-
-
-#[test]
-fn detach_1() {
-    let arena = &mut Arena::new();
-    let root = arena.new_node("+", "Expr", 0);
-    let n1 = arena.new_node("1", "INT", 4);
-    arena.make_child_of(n1, root).unwrap();
-    let n2 = arena.new_node("*", "Expr", 4);
-    arena.make_child_of(n2, root).unwrap();
-    let n3 = arena.new_node("3", "INT", 8);
-    arena.make_child_of(n3, n2).unwrap();
-    let n4 = arena.new_node("4", "INT", 8);
-    arena.make_child_of(n4, n2).unwrap();
-    let first_format = "Expr +
-    INT 1
-    Expr *
-        INT 3
-        INT 4
-";
-    assert_eq!(first_format, format!("{:}", arena));
-    root.detach_with_children(arena);
-    let second_format = "Expr +\n";
-    assert_eq!(second_format, format!("{:}", arena));
-}
-
-#[test]
-fn detach_2() {
-    let arena = &mut Arena::new();
-    let root = arena.new_node("+", "Expr", 0);
-    let n1 = arena.new_node("1", "INT", 4);
-    arena.make_child_of(n1, root).unwrap();
-    let n2 = arena.new_node("*", "Expr", 4);
-    arena.make_child_of(n2, root).unwrap();
-    let n3 = arena.new_node("3", "INT", 8);
-    arena.make_child_of(n3, n2).unwrap();
-    let n4 = arena.new_node("4", "INT", 8);
-    arena.make_child_of(n4, n2).unwrap();
-    let first_format = "Expr +
-    INT 1
-    Expr *
-        INT 3
-        INT 4
-";
-    assert_eq!(first_format, format!("{:}", arena));
-    n2.detach_with_children(arena);
-    let second_format = "Expr +
-    INT 1
-";
-    assert_eq!(second_format, format!("{:}", arena));
-}
-
-#[test]
-fn children_iterator() {
-    let arena = &mut Arena::new();
-    let root = arena.new_node("+", "Expr", 0);
-    let n1 = arena.new_node("1", "INT", 4);
-    arena.make_child_of(n1, root).unwrap();
-    let n2 = arena.new_node("*", "Expr", 4);
-    arena.make_child_of(n2, root).unwrap();
-    let n3 = arena.new_node("3", "INT", 8);
-    arena.make_child_of(n3, n2).unwrap();
-    let n4 = arena.new_node("4", "INT", 8);
-    arena.make_child_of(n4, n2).unwrap();
-    // Children of root.
-    let expected1: Vec<NodeId> = vec![NodeId { index: 1 }, NodeId { index: 2 }];
-    let root_child_ids: Vec<NodeId> = root.children(&arena).collect();
-    assert_eq!(expected1.len(), root_child_ids.len());
-    for index in 0..expected1.len() {
-        assert_eq!(expected1[index], root_child_ids[index]);
+        assert_eq!(expected, format!("{:}", arena));
     }
-    // Children of n2.
-    let expected2: Vec<NodeId> = vec![NodeId { index: 3 }, NodeId { index: 4 }];
-    let n2_child_ids: Vec<NodeId> = n2.children(&arena).collect();
-    assert_eq!(expected2.len(), n2_child_ids.len());
-    for index in 0..expected2.len() {
-        assert_eq!(expected2[index], n2_child_ids[index]);
+
+    #[test]
+    fn get_edges_1() {
+        let arena: Arena<String, String> = Arena::new();
+        assert!(arena.is_empty());
+        let edges: Vec<EdgeId> = vec![];
+        assert_eq!(edges, arena.get_edges());
+    }
+
+    #[test]
+    fn get_edges_2() {
+        let arena = &mut Arena::new();
+        arena.new_node("1", "INT", 0);
+        let edges: Vec<EdgeId> = vec![];
+        assert_eq!(edges, arena.get_edges());
+    }
+
+    #[test]
+    fn get_edges_3() {
+        let arena = &mut Arena::new();
+        let root = arena.new_node("+", "Expr", 0);
+        let n1 = arena.new_node("1", "INT", 4);
+        arena.make_child_of(n1, root).unwrap();
+        let n2 = arena.new_node("*", "Expr", 4);
+        arena.make_child_of(n2, root).unwrap();
+        let n3 = arena.new_node("3", "INT", 8);
+        arena.make_child_of(n3, n2).unwrap();
+        let n4 = arena.new_node("4", "INT", 8);
+        arena.make_child_of(n4, n2).unwrap();
+        let edges: Vec<EdgeId> = vec![(NodeId::new(0), NodeId::new(1)),
+                                      (NodeId::new(0), NodeId::new(2)),
+                                      (NodeId::new(2), NodeId::new(3)),
+                                      (NodeId::new(2), NodeId::new(4))];
+        assert_eq!(edges, arena.get_edges());
+    }
+
+
+    #[test]
+    fn detach_1() {
+        let arena = &mut Arena::new();
+        let root = arena.new_node("+", "Expr", 0);
+        let n1 = arena.new_node("1", "INT", 4);
+        arena.make_child_of(n1, root).unwrap();
+        let n2 = arena.new_node("*", "Expr", 4);
+        arena.make_child_of(n2, root).unwrap();
+        let n3 = arena.new_node("3", "INT", 8);
+        arena.make_child_of(n3, n2).unwrap();
+        let n4 = arena.new_node("4", "INT", 8);
+        arena.make_child_of(n4, n2).unwrap();
+        let first_format = "Expr +
+    INT 1
+    Expr *
+        INT 3
+        INT 4
+";
+        assert_eq!(first_format, format!("{:}", arena));
+        root.detach_with_children(arena);
+        let second_format = "Expr +\n";
+        assert_eq!(second_format, format!("{:}", arena));
+    }
+
+    #[test]
+    fn detach_2() {
+        let arena = &mut Arena::new();
+        let root = arena.new_node("+", "Expr", 0);
+        let n1 = arena.new_node("1", "INT", 4);
+        arena.make_child_of(n1, root).unwrap();
+        let n2 = arena.new_node("*", "Expr", 4);
+        arena.make_child_of(n2, root).unwrap();
+        let n3 = arena.new_node("3", "INT", 8);
+        arena.make_child_of(n3, n2).unwrap();
+        let n4 = arena.new_node("4", "INT", 8);
+        arena.make_child_of(n4, n2).unwrap();
+        let first_format = "Expr +
+    INT 1
+    Expr *
+        INT 3
+        INT 4
+";
+        assert_eq!(first_format, format!("{:}", arena));
+        n2.detach_with_children(arena);
+        let second_format = "Expr +
+    INT 1
+";
+        assert_eq!(second_format, format!("{:}", arena));
+    }
+
+    #[test]
+    fn children_iterator() {
+        let arena = &mut Arena::new();
+        let root = arena.new_node("+", "Expr", 0);
+        let n1 = arena.new_node("1", "INT", 4);
+        arena.make_child_of(n1, root).unwrap();
+        let n2 = arena.new_node("*", "Expr", 4);
+        arena.make_child_of(n2, root).unwrap();
+        let n3 = arena.new_node("3", "INT", 8);
+        arena.make_child_of(n3, n2).unwrap();
+        let n4 = arena.new_node("4", "INT", 8);
+        arena.make_child_of(n4, n2).unwrap();
+        // Children of root.
+        let expected1: Vec<NodeId> = vec![NodeId { index: 1 }, NodeId { index: 2 }];
+        let root_child_ids: Vec<NodeId> = root.children(&arena).collect();
+        assert_eq!(expected1.len(), root_child_ids.len());
+        for index in 0..expected1.len() {
+            assert_eq!(expected1[index], root_child_ids[index]);
+        }
+        // Children of n2.
+        let expected2: Vec<NodeId> = vec![NodeId { index: 3 }, NodeId { index: 4 }];
+        let n2_child_ids: Vec<NodeId> = n2.children(&arena).collect();
+        assert_eq!(expected2.len(), n2_child_ids.len());
+        for index in 0..expected2.len() {
+            assert_eq!(expected2[index], n2_child_ids[index]);
+        }
+    }
+
+    #[test]
+    fn size() {
+        let arena = &mut Arena::new();
+        assert_eq!(0, arena.size());
+        let _ = arena.new_node("+", "Expr", 0);
+        assert_eq!(1, arena.size());
+        let _ = arena.new_node("1", "INT", 4);
+        assert_eq!(2, arena.size());
+        let _ = arena.new_node("*", "Expr", 4);
+        assert_eq!(3, arena.size());
+        let _ = arena.new_node("3", "INT", 8);
+        assert_eq!(4, arena.size());
+        let _ = arena.new_node("4", "INT", 8);
+        assert_eq!(5, arena.size());
     }
 }

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -1,0 +1,109 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file //
+// if one is included with the Software (each a “Larger Work” to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#![warn(missing_docs)]
+
+use std::borrow::Cow::Owned;
+use std::fs::File;
+use std::io::{Error, Write};
+
+use dot::{Id, Edges, GraphWalk, Labeller, LabelText, Nodes, render};
+
+use ast::{Arena, EdgeId, NodeId};
+
+/// Errors produced in emitting new data.
+pub enum EmitterError {
+    /// Could not create a new file.
+    CouldNotCreateFile,
+    /// Could not write out to a file.
+    CouldNotWriteToFile,
+}
+
+/// Write out a graphviz file (in dot format) to `filepath`.
+pub fn write_dotfile_to_disk(filepath: &str,
+                             arena: &Arena<String, String>)
+                             -> Result<(), EmitterError> {
+
+    let mut dotfile = File::create(&filepath)
+        .map_err(|_| EmitterError::CouldNotCreateFile)?;
+    arena
+        .render_dotgraph(&mut dotfile)
+        .map_err(|_| EmitterError::CouldNotWriteToFile)
+}
+
+impl<'a> Labeller<'a, NodeId, EdgeId> for Arena<String, String> {
+    fn graph_id(&self) -> Id {
+        Id::new("AST").unwrap()
+    }
+
+    fn node_id(&self, id: &NodeId) -> Id {
+        // Node ids must be unique dot identifiers, be non-empty strings made up
+        // of alphanumeric or underscore characters, not beginning with a digit
+        // (i.e. the regular expression [a-zA-Z_][a-zA-Z_0-9]*).
+        Id::new(format!("N{}", id)).unwrap()
+    }
+
+    fn node_label(&self, id: &NodeId) -> LabelText {
+        let label = format!("{} {}", self[*id].ty, self[*id].data);
+        LabelText::LabelStr(label.into())
+    }
+}
+
+impl<'a, T, U> GraphWalk<'a, NodeId, EdgeId> for Arena<T, U> {
+    fn nodes(&self) -> Nodes<'a, NodeId> {
+        Owned((0..self.size()).map(NodeId::new).collect())
+    }
+
+    fn edges(&'a self) -> Edges<'a, EdgeId> {
+        Owned(self.get_edges())
+    }
+
+    fn source(&self, e: &EdgeId) -> NodeId {
+        e.0
+    }
+
+    fn target(&self, e: &EdgeId) -> NodeId {
+        e.1
+    }
+}
+
+impl Arena<String, String> {
+    /// Create a graphviz representation of this arena and write to buffer.
+    pub fn render_dotgraph<W: Write>(&self, buffer: &mut W) -> Result<(), Error> {
+        render(self, buffer)
+    }
+}

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -83,7 +83,7 @@ impl<'a> Labeller<'a, NodeId, EdgeId> for Arena<String, String> {
     }
 }
 
-impl<'a, T, U> GraphWalk<'a, NodeId, EdgeId> for Arena<T, U> {
+impl<'a, T: Clone, U: Clone> GraphWalk<'a, NodeId, EdgeId> for Arena<T, U> {
     fn nodes(&self) -> Nodes<'a, NodeId> {
         Owned((0..self.size()).map(NodeId::new).collect())
     }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -51,10 +51,18 @@ extern crate lrpar;
 /// into an AST.
 pub mod ast;
 
+/// Emitters generate output for the user in a variety of formats (e.g. JSON, Graphviz).
+pub mod emitters;
+
 // Re-exported enums and structs.
 pub use ast::ParseError;
 pub use ast::Arena;
 pub use ast::ArenaError;
+pub use ast::EdgeId;
+pub use ast::Node;
+pub use ast::NodeId;
+pub use emitters::EmitterError;
 
 // Re-exported functions.
 pub use ast::parse_file;
+pub use emitters::write_dotfile_to_disk;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -45,6 +45,9 @@ extern crate lrlex;
 extern crate lrtable;
 extern crate lrpar;
 
+/// Actions are operations that transform abstract syntax trees.
+pub mod action;
+
 /// AST defines the abstract syntax tree types that the differ works on.
 ///
 /// Routines are provided to create and iterate over ASTs, and to parse a file
@@ -54,14 +57,14 @@ pub mod ast;
 /// Emitters generate output for the user in a variety of formats (e.g. JSON, Graphviz).
 pub mod emitters;
 
-// Re-exported enums and structs.
-pub use ast::ParseError;
-pub use ast::Arena;
-pub use ast::ArenaError;
-pub use ast::EdgeId;
-pub use ast::Node;
-pub use ast::NodeId;
+// Re-exported enums, structs and types.
+pub use action::{Delete, Insert, Move, Update};
+pub use ast::{Arena, ArenaError, ArenaResult, ParseError};
+pub use ast::{EdgeId, Node, NodeId};
 pub use emitters::EmitterError;
+
+// Re-exported traits.
+pub use action::ApplyAction;
 
 // Re-exported functions.
 pub use ast::parse_file;


### PR DESCRIPTION
An *action* in a tree differ, is some operation that transforms part of an AST (e.g. by deleting a node or inserting a new one).

This PR adds a new `treediff::action` module, which implements the four actions used by GumTree:

  * Delete
  * Insert
  * Move
  * Update

These can be seen in the original [Java code here](https://github.com/GumTreeDiff/gumtree/tree/develop/core/src/main/java/com/github/gumtreediff/actions/model).

It may also be useful to see the GT [code that applies actions to trees](https://github.com/GumTreeDiff/gumtree/blob/297b8f03752cd1a2dc973f637f845b79bcec5741/core/src/main/java/com/github/gumtreediff/actions/ActionUtil.java), and a [concrete implementation of a GT tree](https://github.com/GumTreeDiff/gumtree/blob/297b8f03752cd1a2dc973f637f845b79bcec5741/core/src/main/java/com/github/gumtreediff/tree/Tree.java).

### Design

Each action is implemented as a struct that must implement the `treediff::action::ApplyAction` trait. Only `ApplyAction` and `fmt::Display` have been implemented. 

A core part of the GT design is to create a list of actions and apply them to an AST. Similarly, we can do this with the `treediff::action::ActionList` type, which allows us to treat actions as if they were polymorphic types. e.g.

```rust
let mut arena = create_arena();
let format1 = "Expr +
  INT 1
  Expr *
    INT 3
    INT 4
";
assert_eq!(format1, format!("{}", arena));
// Create action list.
let mut actions: ActionList<String, String> = vec![];
let del = Delete { node: NodeId::new(2) }; // Remove "Expr *".
let ins = Insert {
    data: String::from("2"),
    ty: String::from("INT"),
    indent: 2,
    new_parent: NodeId::new(0),
    nth_child: 1,
};
let upd = Update {
    // Change "+" to "*".
    node: NodeId::new(0),
    value: String::from("*"),
    ty: String::from("Expr"),
};
actions.push(Box::new(del));
actions.push(Box::new(ins));
actions.push(Box::new(upd));
// Apply action list.
actions.apply(&mut arena).unwrap();
let format2 = "Expr *
  INT 1
  INT 2
";
assert_eq!(format2, format!("{}", arena));
```

### Testing

The behaviour of the `rstreediff` binary is unchanged by this PR, so we rely on unit tests.