### PR TITLE
First matcher module PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 [[package]]
 name = "lrtable"
 version = "0.1.0"
-source = "git+http://github.com/softdevteam/lrtable#22ad6c688516ff944ddddbde82bede8999966ceb"
+source = "git+http://github.com/softdevteam/lrtable#8d23cdfd639bfb71487a51bd315f142124d90c09"
 dependencies = [
  "bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "thread-id"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -243,7 +243,7 @@ name = "thread_local"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -309,7 +309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-"checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
+"checksum thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8df7875b676fddfadffd96deea3b1124e5ede707d4884248931077518cf1f773"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
 "checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -12,7 +12,7 @@
 // the Larger Works (as defined below), to deal in both
 //
 // (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file //
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
 // if one is included with the Software (each a “Larger Work” to which the Software
 // is contributed by such licensors),
 //

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -344,6 +344,11 @@ impl NodeId {
         NodeId { index: index }
     }
 
+    /// Return the index of this Node Id.
+    pub fn id(&self) -> usize {
+        self.index
+    }
+
     /// Detach this node, leaving its children unaffected.
     ///
     /// Detaching a node makes it inaccessible to other nodes. The node is not

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -12,7 +12,7 @@
 // the Larger Works (as defined below), to deal in both
 //
 // (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file //
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
 // if one is included with the Software (each a “Larger Work” to which the Software
 // is contributed by such licensors),
 //

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -479,8 +479,8 @@ fn parse_into_ast(pt: &parser::Node<u16>, grm: &Grammar, input: &str) -> Arena<S
     let mut child_node: NodeId;
     while !st.is_empty() {
         let (indent, e) = st.pop().unwrap();
-        match e {
-            &parser::Node::Terminal { lexeme } => {
+        match *e {
+            parser::Node::Terminal { lexeme } => {
                 let token_id: usize = lexeme.tok_id().try_into().ok().unwrap();
                 let term_name = grm.term_name(TIdx::from(token_id)).unwrap();
                 let lexeme_string = &input[lexeme.start()..lexeme.start() + lexeme.len()];
@@ -493,10 +493,10 @@ fn parse_into_ast(pt: &parser::Node<u16>, grm: &Grammar, input: &str) -> Arena<S
                     }
                 };
             }
-            &parser::Node::Nonterminal {
-                 nonterm_idx,
-                 ref nodes,
-             } => {
+            parser::Node::Nonterminal {
+                nonterm_idx,
+                ref nodes,
+            } => {
                 // A non-terminal has no value of its own, but has a node type.
                 child_node = arena.new_node("".to_string(),
                                             grm.nonterm_name(nonterm_idx).unwrap().to_string(),

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -12,7 +12,7 @@
 // the Larger Works (as defined below), to deal in both
 //
 // (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file //
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
 // if one is included with the Software (each a “Larger Work” to which the Software
 // is contributed by such licensors),
 //

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -69,6 +69,7 @@ pub use matchers::{Mapping, MappingStore};
 
 // Re-exported traits.
 pub use action::ApplyAction;
+pub use emitters::RenderDotfile;
 
 // Re-exported functions.
 pub use ast::parse_file;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -12,7 +12,7 @@
 // the Larger Works (as defined below), to deal in both
 //
 // (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file //
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
 // if one is included with the Software (each a “Larger Work” to which the Software
 // is contributed by such licensors),
 //

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@
 // the Larger Works (as defined below), to deal in both
 //
 // (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file //
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
 // if one is included with the Software (each a “Larger Work” to which the Software
 // is contributed by such licensors),
 //


### PR DESCRIPTION
The PR contains some basic infrastructure for a `matchers` module. A matcher is an algorithm which compares two ASTs, and produces a mapping between similar nodes.

This PR contains some basic structs, constructors, etc. and an implementation of the traits needed to produce a GrahViz description of the two ASTs and their mappings. This can be output on the command line with the new `-m <file>` flag. Mappings between AST nodes are shown with dashed lines, rather than solid, for example:

```sh
$ ./target/debug/rstreediff -m map.dot tests/add.calc tests/mult.calc
$ dot map.dot -Tpng -omap.png
``` 

produces this output:

![map](https://cloud.githubusercontent.com/assets/97674/26069573/450e2e5e-3999-11e7-8cbd-97f0e89260bb.png)

[Needs squashing]