### PR TITLE
Second matcher module PR

### DIFF
--- a/src/lib/hqueue.rs
+++ b/src/lib/hqueue.rs
@@ -1,0 +1,325 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a “Larger Work” to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#![warn(missing_docs)]
+
+use std::cmp::Ordering;
+use std::fmt;
+
+use ast::{Arena, NodeId};
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+/// A `PriorityNodeId` wraps the height of a node with its id.
+///
+/// This type should be completely opaque to clients of this module.
+/// Client code should construct a `HeightQueue` and call its methods,
+/// which will return `NodeId`s directly, rather than the `PriorityNodeId`
+/// wrapper.
+struct PriorityNodeId {
+    index: NodeId,
+    height: u32,
+}
+
+impl PriorityNodeId {
+    fn new(index: NodeId, height: u32) -> PriorityNodeId {
+        PriorityNodeId {
+            index: index,
+            height: height,
+        }
+    }
+
+    fn id(&self) -> NodeId {
+        self.index
+    }
+
+    fn height(&self) -> u32 {
+        self.height
+    }
+}
+
+impl Ord for PriorityNodeId {
+    fn cmp(&self, other: &PriorityNodeId) -> Ordering {
+        self.height.cmp(&other.height)
+    }
+}
+
+impl PartialOrd for PriorityNodeId {
+    fn partial_cmp(&self, other: &PriorityNodeId) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+/// A queue of `NodeId`s sorted on the height of their respective nodes.
+pub struct HeightQueue {
+    queue: Vec<PriorityNodeId>, // Use Vec so we can call `sort()`.
+}
+
+impl fmt::Debug for HeightQueue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "[ ")?;
+        for item in &self.queue {
+            write!(f, "({:?}, {:?}) ", item.id(), item.height())?;
+        }
+        write!(f, "]")
+    }
+}
+
+impl HeightQueue {
+    /// Create empty priority queue.
+    pub fn new() -> HeightQueue {
+        HeightQueue { queue: Vec::new() }
+    }
+
+    /// Remove (and discard) all items in this queue, leaving it empty.
+    pub fn clear(&mut self) {
+        self.queue.clear();
+    }
+
+    /// `true` if this queue is empty, `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    /// Get the id of the `Node` with the greatest height in the current queue.
+    pub fn peek_max(&self) -> Option<NodeId> {
+        if self.queue.is_empty() {
+            return None;
+        }
+        return Some(self.queue[self.queue.len() - 1].index);
+    }
+
+    /// Remove information about the tallest node and return its `NodeId`.
+    pub fn pop(&mut self) -> Option<NodeId> {
+        if self.is_empty() {
+            return None;
+        }
+        Some(self.queue.pop().unwrap().index)
+    }
+
+    /// Push a new node into this priority queue, keeping the queue sorted.
+    ///
+    /// This method has no effect if the new node is already in the queue.
+    pub fn push<T: Clone>(&mut self, index: NodeId, arena: &Arena<T>) {
+        let height = index.height(arena);
+        let new_node = PriorityNodeId::new(index, height);
+        if self.queue.contains(&new_node) {
+            // Case 1: new node is already in the queue.
+            return;
+        } else if self.is_empty() || height <= self.queue[0].height() {
+            // Case 2: new node is the shortest in the queue.
+            self.queue.insert(0, new_node);
+        } else if height >= self.queue[self.queue.len() - 1].height() {
+            // Case 3: new node is the tallest in the queue.
+            self.queue.push(new_node);
+        } else {
+            // Case 4: new node needs to be somewhere in the middle of the queue.
+            for index in 0..self.queue.len() - 1 {
+                if self.queue[index].height() <= height && self.queue[index + 1].height() > height {
+                    self.queue.insert(index + 1, new_node);
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Insert all the children of `parent` into this queue, keeping it sorted.
+    pub fn open<T: Clone>(&mut self, parent: &NodeId, arena: Arena<T>) {
+        let children = parent.children(&arena).collect::<Vec<NodeId>>();
+        for child in children {
+            self.push(child, &arena);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test::Bencher;
+
+    fn create_arena() -> Arena<String> {
+        let mut arena = Arena::new();
+        let root = arena.new_node(String::from("+"), String::from("Expr"), 0);
+        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2);
+        arena.make_child_of(n1, root).unwrap();
+        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2);
+        arena.make_child_of(n2, root).unwrap();
+        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4);
+        arena.make_child_of(n3, n2).unwrap();
+        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4);
+        arena.make_child_of(n4, n2).unwrap();
+        let format1 = "Expr +
+  INT 1
+  Expr *
+    INT 3
+    INT 4
+";
+        assert_eq!(format1, format!("{}", arena));
+        arena
+    }
+
+    // Assert that `queue` is in sorted order and has the same size `arena`.
+    fn assert_sorted<T: Clone>(queue: &HeightQueue, arena: &Arena<T>) {
+        let mut expected = arena.size();
+        if expected == 0 {
+            assert!(queue.is_empty());
+            return;
+        }
+        let mut clone = queue.clone();
+        let mut tallest = clone.pop().unwrap();
+        expected -= 1;
+        while !clone.is_empty() {
+            assert!(expected > 0);
+            assert!(tallest.height(arena) >= clone.peek_max().unwrap().height(arena));
+            tallest = clone.pop().unwrap();
+            expected -= 1;
+        }
+        assert_eq!(0, expected);
+    }
+
+    #[test]
+    fn clear() {
+        let arena = create_arena();
+        let mut queue = arena.get_priority_queue();
+        assert!(!queue.is_empty());
+        queue.clear();
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn cmp_priority_node() {
+        let p0 = PriorityNodeId::new(NodeId::new(0), 0);
+        let p1 = PriorityNodeId::new(NodeId::new(0), 1);
+        let p2 = PriorityNodeId::new(NodeId::new(0), 2);
+        let p3 = PriorityNodeId::new(NodeId::new(0), 2);
+        assert!(p0 < p1);
+        assert!(p1 < p2);
+        assert!(p2 == p3);
+        assert!(p0 < p3);
+        assert!(p3 > p1);
+        assert!(p2 > p1);
+        assert!(p3 > p0);
+    }
+
+    #[test]
+    fn fmt_debug() {
+        let arena = create_arena();
+        let queue = arena.get_priority_queue();
+        let s = format!("{:?}", queue);
+        // Three leaves in this arena can be placed in the queue in any order,
+        // so we don't check the whole string, we just check the start of the
+        // formatted string and the branch nodes at the end.
+        let expected = " (NodeId { index: 2 }, 2) (NodeId { index: 0 }, 3) ]";
+        assert_eq!("[ (NodeId { index:", s[..18].to_string());
+        assert_eq!(expected, s[76..].to_string());
+        assert_eq!(128, s.len());
+    }
+
+    #[test]
+    fn new() {
+        assert!(HeightQueue::new().is_empty());
+    }
+
+    #[test]
+    fn open() {
+        let arena = create_arena();
+        let mut queue = HeightQueue::new();
+        queue.open(&NodeId::new(0), arena);
+        assert_eq!(NodeId::new(2), queue.pop().unwrap()); // Expr *
+        assert_eq!(NodeId::new(1), queue.pop().unwrap()); // INT 1
+    }
+
+    #[test]
+    fn peek_max() {
+        let arena = create_arena();
+        let queue = arena.get_priority_queue();
+        let root = queue.peek_max().unwrap();
+        assert_eq!(0, root.id());
+        assert_eq!(3, root.height(&arena));
+    }
+
+    #[test]
+    fn pop() {
+        let arena = create_arena();
+        let mut queue = arena.get_priority_queue();
+        assert_eq!(0, queue.pop().unwrap().id());
+        assert_eq!(2, queue.pop().unwrap().id());
+        // Nodes 1, 3, 4 have the same height, and so may be stored in any order.
+        let leaves = vec![1, 3, 4];
+        assert!(leaves.contains(&queue.pop().unwrap().id()));
+        assert!(leaves.contains(&queue.pop().unwrap().id()));
+        assert!(leaves.contains(&queue.pop().unwrap().id()));
+    }
+
+    #[test]
+    fn push() {
+        let arena = create_arena();
+        let queue = arena.get_priority_queue();
+        assert_sorted(&queue, &arena);
+    }
+
+    #[test]
+    fn push_identical_nodes() {
+        let arena = create_arena();
+        let mut queue = HeightQueue::new();
+        queue.push(NodeId::new(0), &arena);
+        let formatted = format!("{:?}", queue);
+        let expected = "[ (NodeId { index: 0 }, 3) ]";
+        assert_eq!(expected, formatted);
+        queue.push(NodeId::new(0), &arena); // Should have no effect.
+        assert_eq!(expected, formatted);
+    }
+
+    const BENCH_ITER: usize = 10000;
+
+    #[bench]
+    fn bench_push(bencher: &mut Bencher) {
+        let mut arena: Arena<String> = Arena::new();
+        for _ in 0..BENCH_ITER {
+            arena.new_node(String::from(""), String::from(""), 0);
+        }
+        let mut queue = HeightQueue::new();
+        // Because `HeightQueues` are sets, each iteration of this
+        // microbenchmark must push a distinct `NodeId` to the queue, to avoid
+        // the optimisation that does not attempt to push an existing value to
+        // the structure.
+        bencher.iter(|| for id in 0..BENCH_ITER {
+                         queue.push(NodeId::new(id), &arena);
+                         queue.clear();
+                     });
+    }
+}

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -61,18 +61,18 @@ impl Mapping {
 
 /// A store of mappings between nodes in different arenas.
 /// Direction is important.
-pub struct MappingStore<T: Clone, U: Clone> {
+pub struct MappingStore<T: Clone> {
     /// Mappings for the stored arenas.
     pub mappings: Vec<Mapping>,
     /// Source arena (treat as immutable).
-    pub from: Arena<T, U>,
+    pub from: Arena<T>,
     /// Destination arena (treat as immutable).
-    pub to: Arena<T, U>,
+    pub to: Arena<T>,
 }
 
-impl<T: Clone, U: Clone> MappingStore<T, U> {
+impl<T: Clone> MappingStore<T> {
     /// Create a new mapping store.
-    fn new(base: Arena<T, U>, diff: Arena<T, U>) -> MappingStore<T, U> {
+    fn new(base: Arena<T>, diff: Arena<T>) -> MappingStore<T> {
         MappingStore {
             mappings: vec![],
             from: base,
@@ -92,9 +92,7 @@ impl<T: Clone, U: Clone> MappingStore<T, U> {
 }
 
 /// Match locations in distinct ASTs.
-pub fn match_trees<'a, T: Clone, U: Clone>(base: Arena<T, U>,
-                                           diff: Arena<T, U>)
-                                           -> MappingStore<T, U> {
+pub fn match_trees<'a, T: Clone>(base: Arena<T>, diff: Arena<T>) -> MappingStore<T> {
     let mut store = MappingStore::new(base, diff);
     if store.from.size() == 0 || store.to.size() == 0 {
         return store;

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -39,6 +39,29 @@
 
 use ast::{Arena, NodeId};
 
+/// Variables required by the matcher algorithm, set by the user.
+pub struct Config {
+    /// Only consider sub-trees for matching if they have a size `< MAX_SIZE`.
+    pub max_size: u16,
+
+    /// Only consider sub-trees for matching if they have a dice value `> MIN_DICE`.
+    pub min_dice: f32,
+
+    /// Only consider sub-trees for matching if they have a height `< MIN_HEIGHT`.
+    pub min_height: u16,
+}
+
+impl Config {
+    /// Create a new matcher configuration with default threshold values.
+    pub fn new() -> Config {
+        Config {
+            max_size: 100,
+            min_dice: 0.3,
+            min_height: 2,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// Mapping between nodes in distinct arenas.
 pub struct Mapping {
@@ -92,7 +115,10 @@ impl<T: Clone> MappingStore<T> {
 }
 
 /// Match locations in distinct ASTs.
-pub fn match_trees<'a, T: Clone>(base: Arena<T>, diff: Arena<T>) -> MappingStore<T> {
+pub fn match_trees<'a, T: Clone>(base: Arena<T>,
+                                 diff: Arena<T>,
+                                 config: Config)
+                                 -> MappingStore<T> {
     let mut store = MappingStore::new(base, diff);
     if store.from.size() == 0 || store.to.size() == 0 {
         return store;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -60,12 +60,13 @@ pub mod emitters;
 /// Matchers create mappings between abstract syntax trees.
 pub mod matchers;
 
+
 // Re-exported enums, structs and types.
 pub use action::{Delete, Insert, Move, Update};
 pub use ast::{Arena, ArenaError, ArenaResult, ParseError};
 pub use ast::{EdgeId, Node, NodeId};
 pub use emitters::EmitterError;
-pub use matchers::{Mapping, MappingStore};
+pub use matchers::{Config, Mapping, MappingStore};
 
 // Re-exported traits.
 pub use action::ApplyAction;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -35,6 +35,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#![feature(test)]
 #![feature(try_from)]
 
 extern crate dot;
@@ -44,6 +45,7 @@ extern crate log;
 extern crate lrlex;
 extern crate lrtable;
 extern crate lrpar;
+extern crate test;
 
 /// Actions are operations that transform abstract syntax trees.
 pub mod action;
@@ -60,6 +62,8 @@ pub mod emitters;
 /// Matchers create mappings between abstract syntax trees.
 pub mod matchers;
 
+/// A queue of `NodeId`s sorted on the height of their respective nodes.
+pub mod hqueue;
 
 // Re-exported enums, structs and types.
 pub use action::{Delete, Insert, Move, Update};
@@ -67,6 +71,7 @@ pub use ast::{Arena, ArenaError, ArenaResult, ParseError};
 pub use ast::{EdgeId, Node, NodeId};
 pub use emitters::EmitterError;
 pub use matchers::{Config, Mapping, MappingStore};
+pub use hqueue::HeightQueue;
 
 // Re-exported traits.
 pub use action::ApplyAction;

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,12 @@ Options:
     -d, --dot <file>  write out GraphViz representations of the input file(s).
     -h, --help        print this help menu and exit.
     -m, --map <file>  write out GraphViz representation of the mapping store.
+    --max-size VAL    consider subtrees for matching only if they have a size
+                      less than VAL.
+    --min-dice VAL    set the similarity threshold used for matching ASTs. Two
+                      trees are mapped if they are mappable and have a dice
+                      coefficient greater than VAL in [0, 1] (default: 0.3).
+    --min-height VAL  match only nodes with a height greater than VAL (default: 2).
     -v, --version     print version information and exit.
 ";
 
@@ -89,6 +95,9 @@ struct Args {
     flag_dot: Vec<String>,
     flag_help: bool,
     flag_map: Option<String>,
+    flag_max_size: Option<u16>,
+    flag_min_dice: Option<f32>,
+    flag_min_height: Option<u16>,
     flag_version: bool,
 }
 
@@ -146,6 +155,25 @@ fn main() {
         process::exit(0);
     }
 
+    // Set any global constants requested by the user. This should be the ONLY
+    // block of code that mutates these values.
+    let mut config = matchers::Config::new();
+    if let Some(value) = args.flag_max_size {
+        info!("User has set value of MAX_SIZE to {}.", value);
+        config.max_size = value;
+    }
+    if let Some(value) = args.flag_min_dice {
+        if value < 0. || value > 1. {
+            exit_with_message("Value for --min-dice must be in interval [0, 1].");
+        }
+        info!("User has set value of MIN_DICE to {}.", value);
+        config.min_dice = value;
+    }
+    if let Some(value) = args.flag_min_height {
+        info!("User has set value of MIN_HEIGHT to {}.", value);
+        config.min_height = value;
+    }
+
     // This function duplicates some checks that are performed by the
     // treediff::ast::parse_file in order to give better error messages.
 
@@ -195,7 +223,7 @@ fn main() {
         write_dotfile_to_disk(&args.flag_dot[1], &ast_diff);
     }
 
-    let mapping = matchers::match_trees(ast_base, ast_diff);
+    let mapping = matchers::match_trees(ast_base, ast_diff, config);
     if args.flag_map.is_some() {
         let map_file = args.flag_map.unwrap();
         info!("User wishes to create graphviz files {:?}.", map_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ fn write_dotfile_to_disk<T: treediff::emitters::RenderDotfile>(filepath: &str, o
     }
 }
 
-fn parse_file(filename: &str, lexer_path: &str, yacc_path: &str) -> ast::Arena<String, String> {
+fn parse_file(filename: &str, lexer_path: &str, yacc_path: &str) -> ast::Arena<String> {
     let error_to_str = |err| {
         use ast::ParseError::*;
         match err {

--- a/tests/Test0.java
+++ b/tests/Test0.java
@@ -1,0 +1,5 @@
+public class Test {
+    public String foo(int i) {
+        if (i == 0) return "Foo!";
+    }
+}

--- a/tests/Test1.java
+++ b/tests/Test1.java
@@ -1,0 +1,6 @@
+public class Test {
+    public String foo(int i) {
+        if (i == 0) return "Bar";
+        else if (i == -1) return "Foo!";
+    }
+}

--- a/tests/test_ast.rs
+++ b/tests/test_ast.rs
@@ -12,7 +12,7 @@
 // the Larger Works (as defined below), to deal in both
 //
 // (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file //
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
 // if one is included with the Software (each a “Larger Work” to which the Software
 // is contributed by such licensors),
 //

--- a/tests/test_hqueue.rs
+++ b/tests/test_hqueue.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a “Larger Work” to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//! Integration tests for hqueue module.
+//! All file paths are relative to the root of the repository.
+
+#[cfg(test)]
+
+extern crate treediff;
+
+use treediff::ast::{Arena, parse_file};
+use treediff::hqueue::HeightQueue;
+
+// Assert that this queue is in sorted order, and has the same size as the arena.
+fn assert_sorted<T: Clone>(queue: &HeightQueue, arena: &Arena<T>) {
+    let mut expected = arena.size();
+    if expected == 0 {
+        assert!(queue.is_empty());
+        return;
+    }
+    let mut clone = queue.clone();
+    let mut tallest = clone.pop().unwrap();
+    expected -= 1;
+    while !clone.is_empty() {
+        assert!(expected > 0);
+        assert!(tallest.height(arena) >= clone.peek_max().unwrap().height(arena));
+        tallest = clone.pop().unwrap();
+        expected -= 1;
+    }
+    assert_eq!(0, expected);
+}
+
+fn assert_sorted_from_file(filepath: &str) {
+    let arena = parse_file(filepath).unwrap();
+    let queue = arena.get_priority_queue();
+    assert_sorted(&queue, &arena);
+}
+
+#[test]
+fn test_empty_calc() {
+    assert_sorted_from_file("tests/empty.calc");
+}
+
+#[test]
+fn test_one_calc() {
+    assert_sorted_from_file("tests/one.calc");
+}
+
+#[test]
+fn test_add_calc() {
+    assert_sorted_from_file("tests/add.calc");
+}
+
+#[test]
+fn test_mult_calc() {
+    assert_sorted_from_file("tests/mult.calc");
+}
+
+#[test]
+fn test_hello_java() {
+    assert_sorted_from_file("tests/Hello.java");
+}


### PR DESCRIPTION
This PR adds some more infrastructure needed by the GT matcher algorithm:

  * A priority queue of height-ordered `NodeId`s has been added in the new `hqueue.rs` module.
  * The user can set a number of thresholds from the command line.
  * The API has been updated a little, to match the nomenclature in the GT paper.
  * The `treediff::ast::Arena` type now takes one type variable, rather than two. The type of labels (i.e. the grammar production for each node) is now always `String`.

New CLI options:

```sh
Usage: rstreediff [options] <base-file> <diff-file>
       rstreediff [options] <base-file> <diff-file> -d <file> ...
       rstreediff (--help | --version)

Diff two input files.

Options:
    -a, --ast         print AST of input files to STDOUT.
    --debug LEVEL     debug level used by logger. Valid (case sensitive) values
                      are: Debug, Error, Info, Trace, Warn.
    -d, --dot <file>  write out GraphViz representations of the input file(s).
    -h, --help        print this help menu and exit.
    -m, --map <file>  write out GraphViz representation of the mapping store.
    --max-size VAL    consider subtrees for matching only if they have a size
                      less than VAL.
    --min-dice VAL    set the similarity threshold used for matching ASTs. Two
                      trees are mapped if they are mappable and have a dice
                      coefficient greater than VAL in [0, 1] (default: 0.3).
    --min-height VAL  match only nodes with a height greater than VAL (default: 2).
    -v, --version     print version information and exit.
```
