### PR TITLE
Third matcher module PR.

### DIFF
--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -150,8 +150,8 @@ impl<T: Clone> ApplyAction<T> for Update<T> {
 impl<T: Clone> ApplyAction<T> for ActionList<T> {
     fn apply(&mut self, arena: &mut Arena<T>) -> ArenaResult {
         // Iterating over indices here avoids having two mutable borrows.
-        for index in 0..self.len() {
-            self[index].apply(arena)?;
+        for action in self {
+            action.apply(arena)?;
         }
         Ok(())
     }

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -366,11 +366,10 @@ impl NodeId {
         if self.is_leaf(arena) {
             return 1;
         }
-        let mut heights = self.children(arena)
+        self.children(arena)
             .map(|child| child.height(arena))
-            .collect::<Vec<u32>>();
-        heights.sort();
-        1 + heights[heights.len() - 1]
+            .max()
+            .unwrap() + 1
     }
 
     /// Detach this node, leaving its children unaffected.
@@ -1202,11 +1201,6 @@ INT 2
     #[test]
     fn height() {
         let arena = create_arena();
-        let root = NodeId::new(0);
-        let n1 = NodeId::new(1);
-        let n2 = NodeId::new(2);
-        let n3 = NodeId::new(3);
-        let n4 = NodeId::new(4);
         let format1 = "Expr +
     INT 1
     Expr *
@@ -1214,11 +1208,11 @@ INT 2
         INT 4
 ";
         assert_eq!(format1, format!("{}", arena));
-        assert_eq!(3, root.height(&arena));
-        assert_eq!(1, n1.height(&arena));
-        assert_eq!(2, n2.height(&arena));
-        assert_eq!(1, n3.height(&arena));
-        assert_eq!(1, n4.height(&arena));
+        assert_eq!(3, NodeId::new(0).height(&arena));
+        assert_eq!(1, NodeId::new(1).height(&arena));
+        assert_eq!(2, NodeId::new(2).height(&arena));
+        assert_eq!(1, NodeId::new(3).height(&arena));
+        assert_eq!(1, NodeId::new(4).height(&arena));
     }
 
     #[test]

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -87,7 +87,7 @@ pub enum ArenaError {
 /// Result type returned by AST operations.
 pub type ArenaResult = Result<(), ArenaError>;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
 /// A node identifier used for indexing nodes within a particular `Arena`.
 ///
 /// A `NodeId` should be immutable, in the sense that no action on a node or

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -465,6 +465,18 @@ impl NodeId {
         Ok(())
     }
 
+    /// If `self` is the *nth* child of its parent, return *n*.
+    pub fn get_child_position<T: Clone>(self, arena: &Arena<T>) -> Option<usize> {
+        if arena[self].parent.is_none() {
+            return None;
+        }
+        arena[self]
+            .parent
+            .unwrap()
+            .children(arena)
+            .position(|val| val == self)
+    }
+
     /// Return an iterator of references to this node’s children.
     pub fn children<T: Clone>(self, arena: &Arena<T>) -> Children<T> {
         Children {
@@ -1207,5 +1219,15 @@ INT 2
         assert_eq!(2, n2.height(&arena));
         assert_eq!(1, n3.height(&arena));
         assert_eq!(1, n4.height(&arena));
+    }
+
+    #[test]
+    fn get_child_position() {
+        let arena = create_arena();
+        assert_eq!(None, NodeId::new(0).get_child_position(&arena));
+        assert_eq!(Some(0), NodeId::new(1).get_child_position(&arena));
+        assert_eq!(Some(1), NodeId::new(2).get_child_position(&arena));
+        assert_eq!(Some(0), NodeId::new(3).get_child_position(&arena));
+        assert_eq!(Some(1), NodeId::new(4).get_child_position(&arena));
     }
 }

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -41,10 +41,10 @@ use std::borrow::Cow::Owned;
 use std::fs::File;
 use std::io::{Error, Write};
 
-use dot::{Id, Edges, GraphWalk, Labeller, LabelText, Nodes, render, Style};
+use dot::{Id, Edges, GraphWalk, Labeller, LabelText, Nodes, render};
 
 use ast::{Arena, EdgeId, NodeId};
-use matchers::{Mapping, MappingStore};
+use matchers::{MappingStore, MappingType};
 
 /// Errors produced in emitting new data.
 pub enum EmitterError {
@@ -54,6 +54,9 @@ pub enum EmitterError {
     CouldNotWriteToFile,
 }
 
+/// Result returned by emitters.
+pub type EmitterResult = Result<(), EmitterError>;
+
 /// Create a graphviz representation of this type and write to buffer.
 pub trait RenderDotfile {
     /// Render a dotfile to `buffer`.
@@ -61,9 +64,7 @@ pub trait RenderDotfile {
 }
 
 /// Write out a graphviz file (in dot format) to `filepath`.
-pub fn write_dotfile_to_disk<'a, T: RenderDotfile>(filepath: &str,
-                                                   graph: &T)
-                                                   -> Result<(), EmitterError> {
+pub fn write_dotfile_to_disk<'a, T: RenderDotfile>(filepath: &str, graph: &T) -> EmitterResult {
     let mut stream = File::create(&filepath)
         .map_err(|_| EmitterError::CouldNotCreateFile)?;
     graph
@@ -113,84 +114,93 @@ impl RenderDotfile for Arena<String> {
     }
 }
 
-impl<'a> Labeller<'a, NodeId, EdgeId> for MappingStore<String> {
-    fn graph_id(&self) -> Id {
-        Id::new("MappingStore").unwrap()
-    }
-
-    fn node_id(&self, id: &NodeId) -> Id {
-        // Node ids must be unique dot identifiers, be non-empty strings made up
-        // of alphanumeric or underscore characters, not beginning with a digit
-        // (i.e. the regular expression [a-zA-Z_][a-zA-Z_0-9]*).
-        if id.id() < self.from.size() {
-            return Id::new(format!("N{}", id)).unwrap(); // Source nodes.
-        }
-        Id::new(format!("M{}", id)).unwrap() // Destination nodes.
-    }
-
-    fn node_label(&self, id: &NodeId) -> LabelText {
-        let size = self.from.size() as usize;
-        let label = if id.id() < self.from.size() {
-            format!("{} {}", self.from[*id].label, self.from[*id].value)
-        } else {
-            let index = NodeId::new(id.id() - size);
-            format!("{} {}", self.to[index].label, self.to[index].value)
-        };
-        LabelText::LabelStr(label.into())
-    }
-
-    /// Edges between nodes within an AST are solid, mappings are dashed.
-    fn edge_style(&self, edge: &EdgeId) -> Style {
-        let size = self.from.size() as usize;
-        if edge.0.id() < size && edge.1.id() >= size {
-            if self.contains(Mapping::new(edge.0.id(), edge.1.id() - size)) {
-                return Style::Dashed;
-            }
-        }
-        Style::Solid
-    }
-}
-
-/// Here, the two arenas and list of mappings in `self` become a single graph.
+/// Render a mapping store as a Graphviz digraph.
 ///
-/// `Nodeid`s in the source arena are left as-is. `Nodeid`s from the destination
-/// arena have the size of the source arena added to them. Likewise each mapping
-/// of the form `(s_id, d_id)` becomes `(s_id, d_id + s_size)`.
-impl<'a, T: Clone> GraphWalk<'a, NodeId, EdgeId> for MappingStore<T> {
-    fn nodes(&self) -> Nodes<'a, NodeId> {
-        let mut nodes: Vec<NodeId> = (0..self.from.size()).map(NodeId::new).collect();
-        for index in 0..self.to.size() {
-            nodes.push(NodeId::new(self.from.size() + index));
+/// The `dot` crate cannot add arbitrary attributes to nodes or edges, or create
+/// subgraphs. Therefore, we provide this custom function.
+pub fn render_mapping_store(store: &MappingStore<String>, filepath: &str) -> EmitterResult {
+    let mut digraph = vec![String::from("digraph MappingStore {\n"),
+                           String::from("\tratio=fill;\n\tfontsize=16\n")];
+    let mut line: String;
+    let mut node: NodeId;
+    let mut attrs: &str;
+    // Node labels for both ASTs.
+    for id in 0..store.from.size() {
+        node = NodeId::new(id);
+        if !store.is_mapped(node, true) {
+            attrs = ", style=filled, fillcolor=lightgrey";
+        } else {
+            attrs = "";
         }
-        Owned(nodes)
+        if store.from[node].value.is_empty() {
+            digraph.push(format!("\tFROM{}[label=\"{} {}\"{}];\n",
+                                 id,
+                                 store.from[node].label,
+                                 store.from[node].value,
+                                 attrs));
+        } else {
+            digraph.push(format!("\tFROM{}[label=\"{}\"{}];\n",
+                                 id,
+                                 store.from[node].label,
+                                 attrs));
+        }
     }
-
-    fn edges(&'a self) -> Edges<'a, EdgeId> {
-        let mut edges: Vec<EdgeId> = self.from.get_edges();
-        let size = self.from.size() as usize;
-        edges.extend(self.to
-                         .get_edges()
-                         .iter()
-                         .map(|x| {
-                                  (NodeId::new(x.0.id() + size), NodeId::new(x.1.id() + size))
-                              }));
-        edges.extend(self.mappings
-                         .iter()
-                         .map(|x| (x.from, NodeId::new(x.to.id() + size))));
-        Owned(edges)
+    for id in 0..store.to.size() {
+        node = NodeId::new(id);
+        if !store.is_mapped(node, false) {
+            attrs = ", style=filled, fillcolor=lightgrey";
+        } else {
+            attrs = "";
+        }
+        if store.to[node].value.is_empty() {
+            digraph.push(format!("\tTO{}[label=\"{} {}\"{}];\n",
+                                 id,
+                                 store.to[node].label,
+                                 store.to[node].value,
+                                 attrs));
+        } else {
+            digraph.push(format!("\tTO{}[label=\"{}\"{}];\n", id, store.to[node].label, attrs));
+        }
     }
-
-    fn source(&self, e: &EdgeId) -> NodeId {
-        e.0
+    // From AST parent relationships.
+    digraph.push(String::from("\tsubgraph clusterFROM {\n"));
+    digraph.push(String::from("\t\tcolor=white;\n"));
+    for (e0, e1) in store.from.get_edges() {
+        line = format!("\t\tFROM{} -> FROM{}[style=solid, arrowhead=vee];\n",
+                       e0.id(),
+                       e1.id());
+        digraph.push(line);
     }
-
-    fn target(&self, e: &EdgeId) -> NodeId {
-        e.1
+    digraph.push(String::from("\t}\n"));
+    // To AST parent relationships.
+    digraph.push(String::from("\tsubgraph clusterTO {\n"));
+    digraph.push(String::from("\t\tcolor=white;\n"));
+    for (e0, e1) in store.to.get_edges() {
+        line = format!("\t\tTO{} -> TO{}[style=solid, arrowhead=vee];\n",
+                       e0.id(),
+                       e1.id());
+        digraph.push(line);
     }
-}
-
-impl RenderDotfile for MappingStore<String> {
-    fn render_dotfile<W: Write>(&self, buffer: &mut W) -> Result<(), Error> {
-        render(self, buffer)
+    digraph.push(String::from("\t}\n"));
+    // Mappings between ASTs.
+    for mapping in &store.mappings {
+        attrs = match mapping.ty {
+            MappingType::ANCHOR => "[style=dotted, color=blue, arrowhead=diamond]",
+            MappingType::CONTAINER => "[style=dotted, color=red, arrowhead=diamond]",
+            MappingType::RECOVERY => "[style=dashed, color=green, arrowhead=diamond]",
+        };
+        line = format!("\tFROM{} -> TO{}{};\n",
+                       mapping.from.id(),
+                       mapping.to.id(),
+                       attrs);
+        digraph.push(line);
     }
+    digraph.push(String::from("}\n"));
+    // Write dotfile to disk.
+    let mut stream = File::create(&filepath)
+        .map_err(|_| EmitterError::CouldNotCreateFile)?;
+    stream
+        .write_all(digraph.join("").as_bytes())
+        .map_err(|_| EmitterError::CouldNotWriteToFile)?;
+    Ok(())
 }

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -183,16 +183,14 @@ pub fn render_mapping_store(store: &MappingStore<String>, filepath: &str) -> Emi
     }
     digraph.push(String::from("\t}\n"));
     // Mappings between ASTs.
-    for mapping in &store.mappings {
-        attrs = match mapping.ty {
+    for (from, val) in &store.from_map {
+        let &(to, ref ty) = val;
+        attrs = match *ty {
             MappingType::ANCHOR => "[style=dotted, color=blue, arrowhead=diamond]",
             MappingType::CONTAINER => "[style=dotted, color=red, arrowhead=diamond]",
             MappingType::RECOVERY => "[style=dashed, color=green, arrowhead=diamond]",
         };
-        line = format!("\tFROM{} -> TO{}{};\n",
-                       mapping.from.id(),
-                       mapping.to.id(),
-                       attrs);
+        line = format!("\tFROM{} -> TO{}{};\n", from.id(), to.id(), attrs);
         digraph.push(line);
     }
     digraph.push(String::from("}\n"));

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -64,7 +64,7 @@ pub trait RenderDotfile {
 }
 
 /// Write out a graphviz file (in dot format) to `filepath`.
-pub fn write_dotfile_to_disk<'a, T: RenderDotfile>(filepath: &str, graph: &T) -> EmitterResult {
+pub fn write_dotfile_to_disk<T: RenderDotfile>(filepath: &str, graph: &T) -> EmitterResult {
     let mut stream = File::create(&filepath)
         .map_err(|_| EmitterError::CouldNotCreateFile)?;
     graph

--- a/src/lib/gt_matcher.rs
+++ b/src/lib/gt_matcher.rs
@@ -37,8 +37,7 @@
 
 #![warn(missing_docs)]
 
-
-use ast::Arena;
+use ast::{Arena, NodeId};
 use matchers::{MappingStore, MappingType, MatchTrees};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -71,8 +70,7 @@ impl<T: Clone> MatchTrees<T> for GumTreeConfig {
         if store.from.size() == 0 || store.to.size() == 0 {
             return store;
         }
-        store.push(0, 0, MappingType::ANCHOR);
-        // TODO: implement classic GumTree algorithm.
+        store.push(NodeId::new(0), NodeId::new(0), MappingType::ANCHOR);
         store
     }
 }

--- a/src/lib/hqueue.rs
+++ b/src/lib/hqueue.rs
@@ -89,6 +89,12 @@ pub struct HeightQueue {
     queue: Vec<PriorityNodeId>, // Use Vec so we can call `sort()`.
 }
 
+impl Default for HeightQueue {
+    fn default() -> HeightQueue {
+        HeightQueue { queue: vec![] }
+    }
+}
+
 impl fmt::Debug for HeightQueue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[ ")?;
@@ -102,7 +108,7 @@ impl fmt::Debug for HeightQueue {
 impl HeightQueue {
     /// Create empty priority queue.
     pub fn new() -> HeightQueue {
-        HeightQueue { queue: Vec::new() }
+        Default::default()
     }
 
     /// Remove (and discard) all items in this queue, leaving it empty.

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -62,7 +62,7 @@ pub mod emitters;
 /// Matchers create mappings between abstract syntax trees.
 pub mod matchers;
 
-/// GumTree matcher.
+/// GT matching algorithm.
 pub mod gt_matcher;
 
 /// A queue of `NodeId`s sorted on the height of their respective nodes.
@@ -74,7 +74,7 @@ pub use ast::{Arena, ArenaError, ArenaResult, ParseError};
 pub use ast::{EdgeId, Node, NodeId};
 pub use emitters::{EmitterError, EmitterResult};
 pub use gt_matcher::GumTreeConfig;
-pub use matchers::{Mapping, MappingStore, MappingType};
+pub use matchers::{MappingStore, MappingType};
 pub use hqueue::HeightQueue;
 
 // Re-exported traits.

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -67,21 +67,3 @@ pub mod gt_matcher;
 
 /// A queue of `NodeId`s sorted on the height of their respective nodes.
 pub mod hqueue;
-
-// Re-exported enums, structs and types.
-pub use action::{Delete, Insert, Move, Update};
-pub use ast::{Arena, ArenaError, ArenaResult, ParseError};
-pub use ast::{EdgeId, Node, NodeId};
-pub use emitters::{EmitterError, EmitterResult};
-pub use gt_matcher::GumTreeConfig;
-pub use matchers::{MappingStore, MappingType};
-pub use hqueue::HeightQueue;
-
-// Re-exported traits.
-pub use action::ApplyAction;
-pub use emitters::RenderDotfile;
-pub use matchers::MatchTrees;
-
-// Re-exported functions.
-pub use ast::parse_file;
-pub use emitters::{render_mapping_store, write_dotfile_to_disk};

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -69,8 +69,8 @@ pub mod hqueue;
 pub use action::{Delete, Insert, Move, Update};
 pub use ast::{Arena, ArenaError, ArenaResult, ParseError};
 pub use ast::{EdgeId, Node, NodeId};
-pub use emitters::EmitterError;
-pub use matchers::{Config, Mapping, MappingStore};
+pub use emitters::{EmitterError, EmitterResult};
+pub use matchers::{Config, Mapping, MappingStore, MappingType};
 pub use hqueue::HeightQueue;
 
 // Re-exported traits.
@@ -79,4 +79,4 @@ pub use emitters::RenderDotfile;
 
 // Re-exported functions.
 pub use ast::parse_file;
-pub use emitters::write_dotfile_to_disk;
+pub use emitters::{render_mapping_store, write_dotfile_to_disk};

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,8 @@ use docopt::Docopt;
 extern crate treediff;
 use treediff::ast;
 use treediff::emitters;
-use treediff::matchers;
+use treediff::gt_matcher;
+use treediff::matchers::MatchTrees;
 
 const USAGE: &'static str = "
 Usage: rstreediff [options] <base-file> <diff-file>
@@ -161,21 +162,21 @@ fn main() {
 
     // Set any global constants requested by the user. This should be the ONLY
     // block of code that mutates these values.
-    let mut config: matchers::Config = Default::default();
+    let mut gt_config: gt_matcher::GumTreeConfig = Default::default();
     if let Some(value) = args.flag_max_size {
         info!("User has set value of MAX_SIZE to {}.", value);
-        config.max_size = value;
+        gt_config.max_size = value;
     }
     if let Some(value) = args.flag_min_dice {
         if value < 0. || value > 1. {
             exit_with_message("Value for --min-dice must be in interval [0, 1].");
         }
         info!("User has set value of MIN_DICE to {}.", value);
-        config.min_dice = value;
+        gt_config.min_dice = value;
     }
     if let Some(value) = args.flag_min_height {
         info!("User has set value of MIN_HEIGHT to {}.", value);
-        config.min_height = value;
+        gt_config.min_height = value;
     }
 
     // This function duplicates some checks that are performed by the
@@ -227,7 +228,7 @@ fn main() {
         write_dotfile_to_disk(&args.flag_dot[1], &ast_diff);
     }
 
-    let mapping = matchers::match_trees(ast_base, ast_diff, &config);
+    let mapping = gt_config.match_trees(ast_base, ast_diff);
     if args.flag_map.is_some() {
         let map_file = args.flag_map.unwrap();
         info!("User wishes to create graphviz files {:?}.", map_file);

--- a/tests/Test1.java
+++ b/tests/Test1.java
@@ -1,5 +1,5 @@
 public class Test {
-    public String foo(int i) {
+    private String foo(int i) {
         if (i == 0) return "Bar";
         else if (i == -1) return "Foo!";
     }

--- a/tests/test_hqueue.rs
+++ b/tests/test_hqueue.rs
@@ -42,10 +42,10 @@
 
 extern crate treediff;
 
-use treediff::ast::{Arena, parse_file};
+use treediff::ast::{Arena, NodeId, parse_file};
 use treediff::hqueue::HeightQueue;
 
-// Assert that this queue is in sorted order, and has the same size as the arena.
+// Assert that `queue` is in sorted order and has the same size `arena`.
 fn assert_sorted<T: Clone>(queue: &HeightQueue, arena: &Arena<T>) {
     let mut expected = arena.size();
     if expected == 0 {
@@ -53,13 +53,20 @@ fn assert_sorted<T: Clone>(queue: &HeightQueue, arena: &Arena<T>) {
         return;
     }
     let mut clone = queue.clone();
-    let mut tallest = clone.pop().unwrap();
-    expected -= 1;
-    while !clone.is_empty() {
-        assert!(expected > 0);
-        assert!(tallest.height(arena) >= clone.peek_max().unwrap().height(arena));
-        tallest = clone.pop().unwrap();
-        expected -= 1;
+    let mut tallest: Vec<NodeId>;
+    loop {
+        tallest = clone.pop();
+        println!("{:?}", tallest);
+        expected -= tallest.len();
+        for node in &tallest {
+            assert_eq!(node.height(arena), tallest[0].height(arena));
+            if !clone.is_empty() {
+                assert!(node.height(arena) > clone.peek_max().unwrap());
+            }
+        }
+        if clone.is_empty() {
+            break;
+        }
     }
     assert_eq!(0, expected);
 }


### PR DESCRIPTION
This is the third, but not the final PR for implementing a basic tree matcher. This PR introduces more scaffolding and basic algorithms which are necessary to implement the GT algorithm.

In this PR:

  * In `hqueue.rs` various parts of the API have been changed to match the description in the GT paper
  * A number of iterators have been added to the AST module, to traverse subtrees in a variety of orders (breadth-first, pre-order, post-order) which will all needed by algorithms coming in later PRs.
  * In `matchers.rs` the mapping store has been re-written to use hash maps, which matched the GT implementation. This allows constant time look-ups of mappings.
  * In `matchers.rs` a number of "similarity" measures have been implemented, which determine how similar two (previously matched) subtrees are.
  * A small number of other necessary methods have been added to `matchers`.
  * Small bits of code clean up in various places.
  * The `dot` crate, which produces GraphViz output is, unfortunately, not very suitable for dealing with mappings. It cannot create subgraphs, and cannot add arbitrary attributes to nodes and edges. Therefore, I've added a custom function to produce GV output for mapping stores, which gives much more information (e.g. which nodes have been mapped and which not, and at which stage of the GT pipeline the nodes were mapped). This roughly matches the figure in the paper. An example (without many mappings!) is:

![map](https://cloud.githubusercontent.com/assets/97674/26284911/74f60d00-3e3d-11e7-95ae-5b3cbcbca235.png)

