### PR TITLE
First infrastructure PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = "0.1.0"
 dependencies = [
  "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dot 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lrlex 0.1.0 (git+http://github.com/softdevteam/lrlex)",
  "lrpar 0.1.0 (git+http://github.com/softdevteam/lrpar)",
  "lrtable 0.1.0 (git+http://github.com/softdevteam/lrtable)",
@@ -44,7 +44,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -56,11 +56,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -89,12 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -104,7 +104,7 @@ source = "git+http://github.com/softdevteam/lrlex#16a8a756bea89c685f960f7eec7d2c
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -120,7 +120,7 @@ dependencies = [
 [[package]]
 name = "lrtable"
 version = "0.1.0"
-source = "git+http://github.com/softdevteam/lrtable#8d23cdfd639bfb71487a51bd315f142124d90c09"
+source = "git+http://github.com/softdevteam/lrtable#4b7f0e89215b0d117b74e56eb9662851ee326d15"
 dependencies = [
  "bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -136,7 +136,7 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -169,12 +169,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -186,7 +186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -218,7 +218,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -227,7 +227,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -287,13 +287,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab32ea6e284d87987066f21a9e809a73c14720571ef34516f0890b3d355ccfd8"
 "checksum dot 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6bad61973e929901dfd6f78054501325546c979692543150055e77e52191a0eb"
-"checksum env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e3856f1697098606fc6cb97a93de88ca3f3bc35bb878c725920e6e82ecf05e83"
+"checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "babb8281da88cba992fa1f4ddec7d63ed96280a1a53ec9b919fd37b53d71e502"
-"checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
+"checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
+"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum lrlex 0.1.0 (git+http://github.com/softdevteam/lrlex)" = "<none>"
 "checksum lrpar 0.1.0 (git+http://github.com/softdevteam/lrpar)" = "<none>"
 "checksum lrtable 0.1.0 (git+http://github.com/softdevteam/lrtable)" = "<none>"
@@ -301,9 +301,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
-"checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
+"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
-"checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
+"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"

--- a/grammars/txt.l
+++ b/grammars/txt.l
@@ -1,0 +1,4 @@
+%%
+([^\n\r\t ])+ WORD
+[\n|\r\n]+ END
+[ \t]+ SPACE

--- a/grammars/txt.y
+++ b/grammars/txt.y
@@ -1,0 +1,4 @@
+%start document
+%%
+document : paragraph "END" | paragraph "END" document;
+paragraph : "WORD" | "WORD" "SPACE" paragraph;

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -165,13 +165,13 @@ mod test {
         let mut arena = Arena::new();
         let root = arena.new_node(String::from("+"), String::from("Expr"), 0);
         let n1 = arena.new_node(String::from("1"), String::from("INT"), 2);
-        arena.make_child_of(n1, root).unwrap();
+        n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2);
-        arena.make_child_of(n2, root).unwrap();
+        n2.make_child_of(root, &mut arena).unwrap();
         let n3 = arena.new_node(String::from("3"), String::from("INT"), 4);
-        arena.make_child_of(n3, n2).unwrap();
+        n3.make_child_of(n2, &mut arena).unwrap();
         let n4 = arena.new_node(String::from("4"), String::from("INT"), 4);
-        arena.make_child_of(n4, n2).unwrap();
+        n4.make_child_of(n2, &mut arena).unwrap();
         arena
     }
 

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -114,91 +114,88 @@ impl RenderDotfile for Arena<String> {
     }
 }
 
-/// Render a mapping store as a Graphviz digraph.
-///
-/// The `dot` crate cannot add arbitrary attributes to nodes or edges, or create
-/// subgraphs. Therefore, we provide this custom function.
-pub fn render_mapping_store(store: &MappingStore<String>, filepath: &str) -> EmitterResult {
-    let mut digraph = vec![String::from("digraph MappingStore {\n"),
-                           String::from("\tratio=fill;\n\tfontsize=16\n")];
-    let mut line: String;
-    let mut node: NodeId;
-    let mut attrs: &str;
-    // Node labels for both ASTs.
-    for id in 0..store.from.size() {
-        node = NodeId::new(id);
-        if !store.is_mapped(node, true) {
-            attrs = ", style=filled, fillcolor=lightgrey";
-        } else {
-            attrs = "";
+impl RenderDotfile for MappingStore<String> {
+    // Because the `dot` crate cannot add arbitrary attributes to nodes and
+    // edges, or create subgraphs and clusters, we render mapping stores to
+    // a dot digraph manually. This produces output similar to the Figure 1
+    // of Falleri et al. (2014).
+    fn render_dotfile<W: Write>(&self, buffer: &mut W) -> Result<(), Error> {
+        let mut digraph = vec![String::from("digraph MappingStore {\n"),
+                               String::from("\tratio=fill;\n\tfontsize=16\n")];
+        let mut line: String;
+        let mut node: NodeId;
+        let mut attrs: &str;
+        // Node labels for both ASTs.
+        for id in 0..self.from.size() {
+            node = NodeId::new(id);
+            if !self.is_mapped(node, true) {
+                attrs = ", style=filled, fillcolor=lightgrey";
+            } else {
+                attrs = "";
+            }
+            if self.from[node].value.is_empty() {
+                digraph.push(format!("\tFROM{}[label=\"{} {}\"{}];\n",
+                                     id,
+                                     self.from[node].label,
+                                     self.from[node].value,
+                                     attrs));
+            } else {
+                digraph.push(format!("\tFROM{}[label=\"{}\"{}];\n",
+                                     id,
+                                     self.from[node].label,
+                                     attrs));
+            }
         }
-        if store.from[node].value.is_empty() {
-            digraph.push(format!("\tFROM{}[label=\"{} {}\"{}];\n",
-                                 id,
-                                 store.from[node].label,
-                                 store.from[node].value,
-                                 attrs));
-        } else {
-            digraph.push(format!("\tFROM{}[label=\"{}\"{}];\n",
-                                 id,
-                                 store.from[node].label,
-                                 attrs));
+        for id in 0..self.to.size() {
+            node = NodeId::new(id);
+            if !self.is_mapped(node, false) {
+                attrs = ", style=filled, fillcolor=lightgrey";
+            } else {
+                attrs = "";
+            }
+            if self.to[node].value.is_empty() {
+                digraph.push(format!("\tTO{}[label=\"{} {}\"{}];\n",
+                                     id,
+                                     self.to[node].label,
+                                     self.to[node].value,
+                                     attrs));
+            } else {
+                digraph.push(format!("\tTO{}[label=\"{}\"{}];\n", id, self.to[node].label, attrs));
+            }
         }
-    }
-    for id in 0..store.to.size() {
-        node = NodeId::new(id);
-        if !store.is_mapped(node, false) {
-            attrs = ", style=filled, fillcolor=lightgrey";
-        } else {
-            attrs = "";
+        // From AST parent relationships.
+        digraph.push(String::from("\tsubgraph clusterFROM {\n"));
+        digraph.push(String::from("\t\tcolor=white;\n"));
+        for (e0, e1) in self.from.get_edges() {
+            line = format!("\t\tFROM{} -> FROM{}[style=solid, arrowhead=vee];\n",
+                           e0.id(),
+                           e1.id());
+            digraph.push(line);
         }
-        if store.to[node].value.is_empty() {
-            digraph.push(format!("\tTO{}[label=\"{} {}\"{}];\n",
-                                 id,
-                                 store.to[node].label,
-                                 store.to[node].value,
-                                 attrs));
-        } else {
-            digraph.push(format!("\tTO{}[label=\"{}\"{}];\n", id, store.to[node].label, attrs));
+        digraph.push(String::from("\t}\n"));
+        // To AST parent relationships.
+        digraph.push(String::from("\tsubgraph clusterTO {\n"));
+        digraph.push(String::from("\t\tcolor=white;\n"));
+        for (e0, e1) in self.to.get_edges() {
+            line = format!("\t\tTO{} -> TO{}[style=solid, arrowhead=vee];\n",
+                           e0.id(),
+                           e1.id());
+            digraph.push(line);
         }
+        digraph.push(String::from("\t}\n"));
+        // Mappings between ASTs.
+        for (from, val) in &self.from_map {
+            let &(to, ref ty) = val;
+            attrs = match *ty {
+                MappingType::ANCHOR => "[style=dotted, color=blue, arrowhead=diamond]",
+                MappingType::CONTAINER => "[style=dotted, color=red, arrowhead=diamond]",
+                MappingType::RECOVERY => "[style=dashed, color=green, arrowhead=diamond]",
+            };
+            line = format!("\tFROM{} -> TO{}{};\n", from.id(), to.id(), attrs);
+            digraph.push(line);
+        }
+        digraph.push(String::from("}\n"));
+        // Write dotfile to stream.
+        buffer.write_all(digraph.join("").as_bytes())
     }
-    // From AST parent relationships.
-    digraph.push(String::from("\tsubgraph clusterFROM {\n"));
-    digraph.push(String::from("\t\tcolor=white;\n"));
-    for (e0, e1) in store.from.get_edges() {
-        line = format!("\t\tFROM{} -> FROM{}[style=solid, arrowhead=vee];\n",
-                       e0.id(),
-                       e1.id());
-        digraph.push(line);
-    }
-    digraph.push(String::from("\t}\n"));
-    // To AST parent relationships.
-    digraph.push(String::from("\tsubgraph clusterTO {\n"));
-    digraph.push(String::from("\t\tcolor=white;\n"));
-    for (e0, e1) in store.to.get_edges() {
-        line = format!("\t\tTO{} -> TO{}[style=solid, arrowhead=vee];\n",
-                       e0.id(),
-                       e1.id());
-        digraph.push(line);
-    }
-    digraph.push(String::from("\t}\n"));
-    // Mappings between ASTs.
-    for (from, val) in &store.from_map {
-        let &(to, ref ty) = val;
-        attrs = match *ty {
-            MappingType::ANCHOR => "[style=dotted, color=blue, arrowhead=diamond]",
-            MappingType::CONTAINER => "[style=dotted, color=red, arrowhead=diamond]",
-            MappingType::RECOVERY => "[style=dashed, color=green, arrowhead=diamond]",
-        };
-        line = format!("\tFROM{} -> TO{}{};\n", from.id(), to.id(), attrs);
-        digraph.push(line);
-    }
-    digraph.push(String::from("}\n"));
-    // Write dotfile to disk.
-    let mut stream = File::create(&filepath)
-        .map_err(|_| EmitterError::CouldNotCreateFile)?;
-    stream
-        .write_all(digraph.join("").as_bytes())
-        .map_err(|_| EmitterError::CouldNotWriteToFile)?;
-    Ok(())
 }

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -126,47 +126,50 @@ impl RenderDotfile for MappingStore<String> {
         let mut node: NodeId;
         let mut attrs: &str;
         // Node labels for both ASTs.
-        for id in 0..self.from.size() {
+        for id in 0..self.from_arena.size() {
             node = NodeId::new(id);
-            if !self.is_mapped(node, true) {
+            if !self.contains_from(&node) {
                 attrs = ", style=filled, fillcolor=lightgrey";
             } else {
                 attrs = "";
             }
-            if self.from[node].value.is_empty() {
+            if self.from_arena[node].value.is_empty() {
                 digraph.push(format!("\tFROM{}[label=\"{} {}\"{}];\n",
                                      id,
-                                     self.from[node].label,
-                                     self.from[node].value,
+                                     self.from_arena[node].label,
+                                     self.from_arena[node].value,
                                      attrs));
             } else {
                 digraph.push(format!("\tFROM{}[label=\"{}\"{}];\n",
                                      id,
-                                     self.from[node].label,
+                                     self.from_arena[node].label,
                                      attrs));
             }
         }
-        for id in 0..self.to.size() {
+        for id in 0..self.to_arena.size() {
             node = NodeId::new(id);
-            if !self.is_mapped(node, false) {
+            if !self.contains_to(&node) {
                 attrs = ", style=filled, fillcolor=lightgrey";
             } else {
                 attrs = "";
             }
-            if self.to[node].value.is_empty() {
+            if self.to_arena[node].value.is_empty() {
                 digraph.push(format!("\tTO{}[label=\"{} {}\"{}];\n",
                                      id,
-                                     self.to[node].label,
-                                     self.to[node].value,
+                                     self.to_arena[node].label,
+                                     self.to_arena[node].value,
                                      attrs));
             } else {
-                digraph.push(format!("\tTO{}[label=\"{}\"{}];\n", id, self.to[node].label, attrs));
+                digraph.push(format!("\tTO{}[label=\"{}\"{}];\n",
+                                     id,
+                                     self.to_arena[node].label,
+                                     attrs));
             }
         }
         // From AST parent relationships.
         digraph.push(String::from("\tsubgraph clusterFROM {\n"));
         digraph.push(String::from("\t\tcolor=white;\n"));
-        for (e0, e1) in self.from.get_edges() {
+        for (e0, e1) in self.from_arena.get_edges() {
             line = format!("\t\tFROM{} -> FROM{}[style=solid, arrowhead=vee];\n",
                            e0.id(),
                            e1.id());
@@ -176,7 +179,7 @@ impl RenderDotfile for MappingStore<String> {
         // To AST parent relationships.
         digraph.push(String::from("\tsubgraph clusterTO {\n"));
         digraph.push(String::from("\t\tcolor=white;\n"));
-        for (e0, e1) in self.to.get_edges() {
+        for (e0, e1) in self.to_arena.get_edges() {
             line = format!("\t\tTO{} -> TO{}[style=solid, arrowhead=vee];\n",
                            e0.id(),
                            e1.id());
@@ -184,7 +187,7 @@ impl RenderDotfile for MappingStore<String> {
         }
         digraph.push(String::from("\t}\n"));
         // Mappings between ASTs.
-        for (from, val) in &self.from_map {
+        for (from, val) in &self.from {
             let &(to, ref ty) = val;
             attrs = match *ty {
                 MappingType::ANCHOR => "[style=dotted, color=blue, arrowhead=diamond]",

--- a/src/lib/gt_matcher.rs
+++ b/src/lib/gt_matcher.rs
@@ -67,7 +67,7 @@ impl<T: Clone> MatchTrees<T> for GumTreeConfig {
     /// Match locations in distinct ASTs.
     fn match_trees(&self, base: Arena<T>, diff: Arena<T>) -> MappingStore<T> {
         let mut store = MappingStore::new(base, diff);
-        if store.from.size() == 0 || store.to.size() == 0 {
+        if store.from_arena.size() == 0 || store.to_arena.size() == 0 {
             return store;
         }
         store.push(NodeId::new(0), NodeId::new(0), MappingType::ANCHOR);

--- a/src/lib/gt_matcher.rs
+++ b/src/lib/gt_matcher.rs
@@ -37,6 +37,8 @@
 
 #![warn(missing_docs)]
 
+use std::fmt::Display;
+
 use ast::{Arena, NodeId};
 use matchers::{MappingStore, MappingType, MatchTrees};
 
@@ -63,7 +65,28 @@ impl Default for GumTreeConfig {
     }
 }
 
-impl<T: Clone> MatchTrees<T> for GumTreeConfig {
+impl GumTreeConfig {
+    /// Create a new configuration object, with default values.
+    pub fn new() -> GumTreeConfig {
+        Default::default()
+    }
+}
+
+impl<T: Clone + Display> MatchTrees<T> for GumTreeConfig {
+    /// Describe this matcher for the user.
+    fn describe(&self) -> String {
+        let desc = "
+This matcher finds implements the GumTree algorithm, which takes account of MOVE
+operations between ASTs.
+
+The GumTree algorithm can be configured with the --min-dice, --max-size and
+--min-height switches. See --help for more details.
+
+For more information see Falleri et al. (2014) Find-Grained and Accurate Source
+Code Differencing.";
+        String::from(desc)
+    }
+
     /// Match locations in distinct ASTs.
     fn match_trees(&self, base: Arena<T>, diff: Arena<T>) -> MappingStore<T> {
         let mut store = MappingStore::new(base, diff);

--- a/src/lib/hqueue.rs
+++ b/src/lib/hqueue.rs
@@ -186,13 +186,13 @@ mod tests {
         let mut arena = Arena::new();
         let root = arena.new_node(String::from("+"), String::from("Expr"), 0);
         let n1 = arena.new_node(String::from("1"), String::from("INT"), 2);
-        arena.make_child_of(n1, root).unwrap();
+        n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2);
-        arena.make_child_of(n2, root).unwrap();
+        n2.make_child_of(root, &mut arena).unwrap();
         let n3 = arena.new_node(String::from("3"), String::from("INT"), 4);
-        arena.make_child_of(n3, n2).unwrap();
+        n3.make_child_of(n2, &mut arena).unwrap();
         let n4 = arena.new_node(String::from("4"), String::from("INT"), 4);
-        arena.make_child_of(n4, n2).unwrap();
+        n4.make_child_of(n2, &mut arena).unwrap();
         let format1 = "Expr +
   INT 1
   Expr *

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -62,6 +62,67 @@ impl Default for MappingType {
 
 /// A store of mappings between nodes in different arenas.
 /// Direction is important.
+pub struct TemporaryMappingStore {
+    /// Mappings from the source tree to the destination.
+    ///
+    /// Should contain the same information as `to_map`.
+    pub from: HashMap<NodeId, NodeId>,
+    /// Mappings from the destination tree to the source.
+    ///
+    /// Should contain the same information as `from_map`.
+    pub to: HashMap<NodeId, NodeId>,
+}
+
+impl TemporaryMappingStore {
+    /// Create a new mapping store.
+    pub fn new() -> TemporaryMappingStore {
+        Default::default()
+    }
+
+    /// Push a new mapping into the store.
+    pub fn push(&mut self, from: NodeId, to: NodeId) {
+        self.from.insert(from, to);
+        self.to.insert(to, from);
+    }
+
+    /// Remove mapping from store.
+    pub fn remove(&mut self, from: &NodeId, to: &NodeId) {
+        self.from.remove(from);
+        self.to.remove(to);
+    }
+
+    /// `true` if the store has a mapping from `from` to another node.
+    pub fn contains_from(&self, from: &NodeId) -> bool {
+        self.from.contains_key(from)
+    }
+
+    /// `true` if the store has a mapping from a node to `to`.
+    pub fn contains_to(&self, to: &NodeId) -> bool {
+        self.to.contains_key(to)
+    }
+
+    /// Get the `NodeId` that `to` is mapped from.
+    pub fn get_from(&self, to: &NodeId) -> Option<NodeId> {
+        self.to.get(to).map_or(None, |x| Some(*x))
+    }
+
+    /// Get the `NodeId` that `from` is mapped to.
+    pub fn get_to(&self, from: &NodeId) -> Option<NodeId> {
+        self.from.get(from).map_or(None, |x| Some(*x))
+    }
+}
+
+impl Default for TemporaryMappingStore {
+    fn default() -> TemporaryMappingStore {
+        TemporaryMappingStore {
+            from: HashMap::new(),
+            to: HashMap::new(),
+        }
+    }
+}
+
+/// A store of mappings between nodes in different arenas.
+/// Direction is important.
 pub struct MappingStore<T: Clone> {
     /// Mappings from the source tree to the destination.
     ///

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -241,13 +241,13 @@ mod tests {
         let mut arena = Arena::new();
         let root = arena.new_node(String::from("+"), String::from("Expr"), 0);
         let n1 = arena.new_node(String::from("1"), String::from("INT"), 2);
-        arena.make_child_of(n1, root).unwrap();
+        n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2);
-        arena.make_child_of(n2, root).unwrap();
+        n2.make_child_of(root, &mut arena).unwrap();
         let n3 = arena.new_node(String::from("3"), String::from("INT"), 4);
-        arena.make_child_of(n3, n2).unwrap();
+        n3.make_child_of(n2, &mut arena).unwrap();
         let n4 = arena.new_node(String::from("4"), String::from("INT"), 4);
-        arena.make_child_of(n4, n2).unwrap();
+        n4.make_child_of(n2, &mut arena).unwrap();
         let format1 = "Expr +
   INT 1
   Expr *
@@ -262,9 +262,9 @@ mod tests {
         let mut arena = Arena::new();
         let root = arena.new_node(String::from("+"), String::from("Expr"), 0);
         let n1 = arena.new_node(String::from("3"), String::from("INT"), 4);
-        arena.make_child_of(n1, root).unwrap();
+        n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node(String::from("4"), String::from("INT"), 4);
-        arena.make_child_of(n2, root).unwrap();
+        n2.make_child_of(root, &mut arena).unwrap();
         let format1 = "Expr +
     INT 3
     INT 4

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -231,6 +231,12 @@ impl<T: Clone> MappingStore<T> {
 pub trait MatchTrees<T: Clone> {
     /// Match two trees and return a store of mappings between them.
     fn match_trees(&self, base: Arena<T>, diff: Arena<T>) -> MappingStore<T>;
+
+    /// Describe the matcher for the user.
+    ///
+    /// This is the string that is printed when the user passes in the --list
+    /// CLI option.
+    fn describe(&self) -> String;
 }
 
 #[cfg(test)]

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -67,3 +67,6 @@ pub mod gt_matcher;
 
 /// A queue of `NodeId`s sorted on the height of their respective nodes.
 pub mod hqueue;
+
+/// Algorithms which act on sequences of values.
+pub mod sequence;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -65,6 +65,11 @@ pub mod matchers;
 /// GT matching algorithm.
 pub mod gt_matcher;
 
+/// Longest common subsequence matching algorithm.
+///
+/// Described in Myers (1986).
+pub mod myers_matcher;
+
 /// A queue of `NodeId`s sorted on the height of their respective nodes.
 pub mod hqueue;
 

--- a/src/lib/myers_matcher.rs
+++ b/src/lib/myers_matcher.rs
@@ -60,7 +60,7 @@ impl MyersConfig {
     }
 }
 
-impl<T: Clone + Display + Eq> MatchTrees<T> for MyersConfig {
+impl<T: Clone + Display + Eq + 'static> MatchTrees<T> for MyersConfig {
     /// Describe this matcher for the user.
     fn describe(&self) -> String {
         let desc = "

--- a/src/lib/myers_matcher.rs
+++ b/src/lib/myers_matcher.rs
@@ -41,59 +41,67 @@ use std::fmt::Display;
 
 use ast::{Arena, NodeId};
 use matchers::{MappingStore, MappingType, MatchTrees};
+use sequence::lcss;
 
 #[derive(Debug, Clone, PartialEq)]
-/// Variables required by the matcher algorithm, set by the user.
-pub struct GumTreeConfig {
-    /// Only consider sub-trees for matching if they have a size `< MAX_SIZE`.
-    pub max_size: u16,
+/// The Myers matcher does not require any configuration.
+pub struct MyersConfig {}
 
-    /// Only consider sub-trees for matching if they have a dice value `> MIN_DICE`.
-    pub min_dice: f32,
-
-    /// Only consider sub-trees for matching if they have a height `< MIN_HEIGHT`.
-    pub min_height: u16,
-}
-
-impl Default for GumTreeConfig {
-    fn default() -> GumTreeConfig {
-        GumTreeConfig {
-            max_size: 100,
-            min_dice: 0.3,
-            min_height: 2,
-        }
+impl Default for MyersConfig {
+    fn default() -> MyersConfig {
+        MyersConfig {}
     }
 }
 
-impl GumTreeConfig {
+impl MyersConfig {
     /// Create a new configuration object, with default values.
-    pub fn new() -> GumTreeConfig {
+    pub fn new() -> MyersConfig {
         Default::default()
     }
 }
 
-impl<T: Clone + Display> MatchTrees<T> for GumTreeConfig {
+impl<T: Clone + Display + Eq> MatchTrees<T> for MyersConfig {
     /// Describe this matcher for the user.
     fn describe(&self) -> String {
         let desc = "
-This matcher implements the GumTree algorithm, which takes account of move
-operations between ASTs.
+This matcher finds the longest common subsequence between two ASTs. Myers is the
+default algorithm used by git-diff.
 
-The GumTree algorithm can be configured with the --min-dice, --max-size and
---min-height switches. See --help for more details.
-
-For more information see Falleri et al. (2014) Find-Grained and Accurate Source
-Code Differencing.";
+For more information see Myers (1986) An O(ND) Difference Algorithm and its
+Variations.";
         String::from(desc)
     }
 
     /// Match locations in distinct ASTs.
     fn match_trees(&self, base: Arena<T>, diff: Arena<T>) -> MappingStore<T> {
         let mut store = MappingStore::new(base, diff);
-        if store.from_arena.size() == 0 || store.to_arena.size() == 0 {
+        if store.from_arena.is_empty() || store.to_arena.is_empty() {
             return store;
         }
-        store.push(NodeId::new(0), NodeId::new(0), MappingType::ANCHOR);
+        let base_pre = NodeId::new(0)
+            .pre_order_traversal(&store.from_arena)
+            .collect::<Vec<NodeId>>();
+        let diff_pre = NodeId::new(0)
+            .pre_order_traversal(&store.to_arena)
+            .collect::<Vec<NodeId>>();
+
+        let longest = lcss(&base_pre,
+                           &store.from_arena,
+                           &diff_pre,
+                           &store.to_arena,
+                           &eq);
+        for &(n1, n2) in &longest {
+            store.push(n1, n2, MappingType::ANCHOR);
+        }
         store
     }
+}
+
+/// Test that two nodes have the same label and value.
+fn eq<T: Clone + Display + Eq>(n1: &NodeId,
+                               arena1: &Arena<T>,
+                               n2: &NodeId,
+                               arena2: &Arena<T>)
+                               -> bool {
+    arena1[*n1].label == arena2[*n2].label && arena1[*n1].value == arena2[*n2].value
 }

--- a/src/lib/sequence.rs
+++ b/src/lib/sequence.rs
@@ -1,0 +1,205 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a “Larger Work” to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#![warn(missing_docs)]
+
+use std::cmp::max;
+
+use ast::{Arena, NodeId};
+
+/// Compute the longest common subsequence of two sequences.
+///
+/// This implementation is designed to work on sequences of `NodeId`s from two
+/// different arenas. The function returns a vector of `(NodeId, NodeId)` pairs,
+/// which are the locations of mapped nodes from the two arenas.
+pub fn lcss<T: Clone + Eq>(seq1: &[NodeId],
+                           arena1: &Arena<T>,
+                           seq2: &[NodeId],
+                           arena2: &Arena<T>,
+                           eq: &Fn(&NodeId, &Arena<T>, &NodeId, &Arena<T>) -> bool)
+                           -> Vec<(NodeId, NodeId)> {
+    let mut lcss: Vec<(NodeId, NodeId)> = vec![];
+    if seq1.is_empty() || seq2.is_empty() {
+        return lcss;
+    }
+    let mut grid = vec![];
+    for _ in 0..seq1.len() + 1 {
+        grid.push(vec![0; seq2.len() + 1]);
+    }
+    debug_assert_eq!(seq1.len() + 1, grid.len());
+    debug_assert_eq!(seq2.len() + 1, grid[0].len());
+    for (i, n1) in seq1.iter().enumerate() {
+        for (j, n2) in seq2.iter().enumerate() {
+            if eq(n1, arena1, n2, arena2) {
+                grid[i + 1][j + 1] = 1 + grid[i][j];
+            } else {
+                grid[i + 1][j + 1] = max(grid[i + 1][j], grid[i][j + 1]);
+            }
+        }
+    }
+    let mut i = seq1.len();
+    let mut j = seq2.len();
+    while i != 0 && j != 0 {
+        if grid[i][j] == grid[i - 1][j] {
+            i -= 1;
+        } else if grid[i][j] == grid[i][j - 1] {
+            j -= 1;
+        } else {
+            lcss.push((seq1[i - 1], seq2[j - 1]));
+            i -= 1;
+            j -= 1;
+        }
+    }
+    lcss.reverse();
+    lcss
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::{Debug, Display};
+    use matchers::MappingStore;
+
+    fn eq<T: Clone + Debug + Eq>(n1: &NodeId,
+                                 arena1: &Arena<T>,
+                                 n2: &NodeId,
+                                 arena2: &Arena<T>)
+                                 -> bool {
+        arena1[*n1].label == arena2[*n2].label && arena1[*n1].value == arena2[*n2].value
+    }
+
+    fn assert_sequence_correct<T: Clone + Debug + Eq>(store: MappingStore<T>, expected: &[T]) {
+        if expected.is_empty() {
+            assert!(lcss(&vec![], &store.from_arena, &vec![], &store.to_arena, &eq).is_empty());
+            return;
+        }
+        let root = NodeId::new(0);
+        let base = root.children(&store.from_arena).collect::<Vec<NodeId>>();
+        let diff = root.children(&store.to_arena).collect::<Vec<NodeId>>();
+        let longest = lcss(&base, &store.from_arena, &diff, &store.to_arena, &eq);
+        for (i, value) in longest.iter().enumerate() {
+            assert_eq!(expected[i], store.from_arena[value.0].value);
+            assert_eq!(expected[i], store.to_arena[value.1].value);
+        }
+    }
+
+    fn create_mapping_store<T: Clone + Default + Display + Eq>(base: &[T],
+                                                               diff: &[T])
+                                                               -> MappingStore<T> {
+        let mut base_arena: Arena<T> = Arena::new();
+        let mut id: NodeId;
+        if !base.is_empty() {
+            let root = base_arena.new_node(Default::default(), String::from("NULL"), 0);
+            for value in base {
+                id = base_arena.new_node(value.clone(), String::from("T"), 0);
+                id.make_child_of(root, &mut base_arena).unwrap();
+
+            }
+        }
+        let mut diff_arena: Arena<T> = Arena::new();
+        if !diff.is_empty() {
+            let root = diff_arena.new_node(Default::default(), String::from("NULL"), 0);
+            for value in diff {
+                id = diff_arena.new_node(value.clone(), String::from("T"), 0);
+                id.make_child_of(root, &mut diff_arena).unwrap();
+            }
+        }
+        let store = MappingStore::new(base_arena, diff_arena);
+        store
+    }
+
+    #[test]
+    fn lcss_chimpanzee() {
+        let v1 = "HUMAN".chars().collect::<Vec<char>>();
+        let v2 = "CHIMPANZEE".chars().collect::<Vec<char>>();
+        let expected = vec!['H', 'M', 'A', 'N'];
+        let store1 = create_mapping_store(&v1, &v2);
+        assert_sequence_correct(store1, &expected);
+        let store2 = create_mapping_store(&v2, &v1);
+        assert_sequence_correct(store2, &expected);
+    }
+
+    #[test]
+    fn lcss_empty() {
+        let empty: Vec<String> = vec![];
+        let store = create_mapping_store(&empty, &empty);
+        assert_sequence_correct(store, &empty);
+    }
+
+    #[test]
+    fn lcss_same() {
+        let same = "THE VERY SAME TWO STRINGS."
+            .chars()
+            .collect::<Vec<char>>();
+        let store = create_mapping_store(&same, &same);
+        assert_sequence_correct(store, &same);
+    }
+
+    #[test]
+    fn lcss_dna() {
+        let v1 = "AAACCGTGAGTTATTCGTTCTAGAA"
+            .chars()
+            .collect::<Vec<char>>();
+        let v2 = "CACCCCTAAGGTACCTTTGGTTC".chars().collect::<Vec<char>>();
+        let expected = "ACCTAGTATTGTTC".chars().collect::<Vec<char>>();
+        let store1 = create_mapping_store(&v1, &v2);
+        assert_sequence_correct(store1, &expected);
+        let store2 = create_mapping_store(&v2, &v1);
+        assert_sequence_correct(store2, &expected);
+    }
+
+    #[test]
+    fn lcss_num() {
+        let v1 = vec![1, 2, 3, 4, 1];
+        let v2 = vec![3, 4, 1, 2, 1, 3];
+        let expected1 = vec![1, 2, 3];
+        let expected2 = vec![3, 4, 1];
+        let store1 = create_mapping_store(&v1, &v2);
+        assert_sequence_correct(store1, &expected1);
+        let store2 = create_mapping_store(&v2, &v1);
+        assert_sequence_correct(store2, &expected2);
+    }
+
+    #[test]
+    fn lcss_wiki() {
+        let v1 = "XMJYAUZ".chars().collect::<Vec<char>>();
+        let v2 = "MZJAWXU".chars().collect::<Vec<char>>();
+        let expected = vec!['M', 'J', 'A', 'U'];
+        let store = create_mapping_store(&v1, &v2);
+        assert_sequence_correct(store, &expected);
+    }
+}

--- a/src/lib/sequence.rs
+++ b/src/lib/sequence.rs
@@ -117,9 +117,9 @@ mod tests {
         }
     }
 
-    fn create_mapping_store<T: Clone + Default + Display + Eq>(base: &[T],
-                                                               diff: &[T])
-                                                               -> MappingStore<T> {
+    fn create_mapping_store<T: Clone + Default + Display + Eq + 'static>(base: &[T],
+                                                                         diff: &[T])
+                                                                         -> MappingStore<T> {
         let mut base_arena: Arena<T> = Arena::new();
         let mut id: NodeId;
         if !base.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,6 @@ fn main() {
     if args.flag_map.is_some() {
         let map_file = args.flag_map.unwrap();
         info!("User wishes to create graphviz files {:?}.", map_file);
-        consume_emitter_err(emitters::render_mapping_store(&mapping, &map_file),
-                            &map_file);
+        write_dotfile_to_disk(&map_file, &mapping);
     }
 }

--- a/tests/lorem1.txt
+++ b/tests/lorem1.txt
@@ -1,0 +1,4 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse et quam magna. Aenean aliquam dignissim neque nec pulvinar. Quisque in lacus vel ex aliquet vestibulum. In molestie ipsum dolor, eu sagittis metus posuere vulputate. Maecenas facilisis, turpis id accumsan pretium, risus tortor volutpat enim, id placerat nunc quam ut lectus. Nunc venenatis feugiat eros, at dapibus velit iaculis nec. Aenean semper, nulla ut condimentum interdum, nisl lorem volutpat nisi. Aliquam in ante a justo pharetra mattis.
+
+
+

--- a/tests/lorem2.txt
+++ b/tests/lorem2.txt
@@ -1,0 +1,2 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse et quam magna. Aenean aliquam dignissim neque nec pulvinar. Quisque in lacus vel ex aliquet vestibulum. Aenean semper, nulla ut condimentum interdum, nisl lorem volutpat nisi, pharetra porta lacus tellus eu eros. Aliquam in ante a justo pharetra mattis. In molestie ipsum dolor, eu sagittis metus posuere vulputate. Maecenas facilisis, turpis id accumsan pretium, risus tortor volutpat enim, id placerat nunc quam ut lectus. Nunc venenatis feugiat eros, at dapibus velit iaculis nec.
+

--- a/tests/test_matcher.rs
+++ b/tests/test_matcher.rs
@@ -35,65 +35,57 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#![warn(missing_docs)]
+//! Integration tests for matcher module, testing the edit script generator.
+//! All file paths are relative to the root of the repository.
 
-use std::fmt::Display;
+extern crate treediff;
 
-use ast::{Arena, NodeId};
-use matchers::{MappingStore, MappingType, MatchTrees};
+use treediff::ast::{NodeId, parse_file};
+use treediff::myers_matcher::MyersConfig;
+use treediff::matchers::MatchTrees;
 
-#[derive(Debug, Clone, PartialEq)]
-/// Variables required by the matcher algorithm, set by the user.
-pub struct GumTreeConfig {
-    /// Only consider sub-trees for matching if they have a size `< MAX_SIZE`.
-    pub max_size: u16,
-
-    /// Only consider sub-trees for matching if they have a dice value `> MIN_DICE`.
-    pub min_dice: f32,
-
-    /// Only consider sub-trees for matching if they have a height `< MIN_HEIGHT`.
-    pub min_height: u16,
-}
-
-impl Default for GumTreeConfig {
-    fn default() -> GumTreeConfig {
-        GumTreeConfig {
-            max_size: 100,
-            min_dice: 0.3,
-            min_height: 2,
-        }
+fn compare_asts_post_edit_script(base_file: &str, diff_file: &str) {
+    let ast_base = parse_file(base_file).unwrap();
+    let ast_diff = parse_file(diff_file).unwrap();
+    let size = ast_diff.size();
+    // All tests use the Myers matcher.
+    let config = MyersConfig::new();
+    // Generate mappings between ASTs.
+    let mut mapping = config.match_trees(ast_base, ast_diff);
+    // Generate edit script. By convention, the parser will generate an AST
+    // whose root is in the 0th element of its arena.
+    let _ = mapping.generate_edit_script(NodeId::new(0));
+    // Once the edit script has been generated, the mapping between the base
+    // and diff ASTs should be a total mapping.
+    assert_eq!(size, mapping.from.len());
+    assert_eq!(size, mapping.to.len());
+    for (key, val) in &mapping.from {
+        assert!(mapping.to.contains_key(&val.0));
+        assert_eq!(*key, mapping.get_from(&val.0).unwrap());
+        assert_eq!(val.0, mapping.get_to(key).unwrap());
     }
 }
 
-impl GumTreeConfig {
-    /// Create a new configuration object, with default values.
-    pub fn new() -> GumTreeConfig {
-        Default::default()
-    }
+#[test]
+fn test_empty_calc() {
+    compare_asts_post_edit_script("tests/empty.calc", "tests/one.calc");
+    compare_asts_post_edit_script("tests/one.calc", "tests/empty.calc");
 }
 
-impl<T: Clone + Display + Eq + 'static> MatchTrees<T> for GumTreeConfig {
-    /// Describe this matcher for the user.
-    fn describe(&self) -> String {
-        let desc = "
-This matcher implements the GumTree algorithm, which takes account of move
-operations between ASTs.
 
-The GumTree algorithm can be configured with the --min-dice, --max-size and
---min-height switches. See --help for more details.
+#[test]
+fn test_gt_example() {
+    // Example from the GumTree paper.
+    compare_asts_post_edit_script("tests/Test0.java", "tests/Test1.java");
+}
 
-For more information see Falleri et al. (2014) Find-Grained and Accurate Source
-Code Differencing.";
-        String::from(desc)
-    }
+#[test]
+fn test_plain_text() {
+    compare_asts_post_edit_script("tests/lorem1.txt", "tests/lorem2.txt");
+}
 
-    /// Match locations in distinct ASTs.
-    fn match_trees(&self, base: Arena<T>, diff: Arena<T>) -> MappingStore<T> {
-        let mut store = MappingStore::new(base, diff);
-        if store.from_arena.size() == 0 || store.to_arena.size() == 0 {
-            return store;
-        }
-        store.push(NodeId::new(0), NodeId::new(0), MappingType::ANCHOR);
-        store
-    }
+#[test]
+fn test_wiki() {
+    // Example from wikipedia.
+    compare_asts_post_edit_script("tests/wiki1.txt", "tests/wiki2.txt");
 }

--- a/tests/wiki1.txt
+++ b/tests/wiki1.txt
@@ -1,0 +1,24 @@
+This part of the
+document has stayed the
+same from version to
+version.  It shouldn't
+be shown if it doesn't
+change.  Otherwise, that
+would not be helping to
+compress the size of the
+changes.
+
+This paragraph contains
+text that is outdated.
+It will be deleted in the
+near future.
+
+It is important to spell
+check this dokument. On
+the other hand, a
+misspelled word isn't
+the end of the world.
+Nothing in the rest of
+this paragraph needs to
+be changed. Things can
+be added after it.

--- a/tests/wiki2.txt
+++ b/tests/wiki2.txt
@@ -1,0 +1,28 @@
+This is an important
+notice! It should
+therefore be located at
+the beginning of this
+document!
+
+This part of the
+document has stayed the
+same from version to
+version.  It shouldn't
+be shown if it doesn't
+change.  Otherwise, that
+would not be helping to
+compress anything.
+
+It is important to spell
+check this document. On
+the other hand, a
+misspelled word isn't
+the end of the world.
+Nothing in the rest of
+this paragraph needs to
+be changed. Things can
+be added after it.
+
+This paragraph contains
+important new additions
+to this document.


### PR DESCRIPTION
This PR introduces some of the infrastructure needed to implement the end-to-end diffing tool, in particular the edit script generation algorithm. 

**NEEDS SQUASHING**

Specifically in this PR:

  * A lot of churn on all the core APIs
  * A simple matching algorithm based on Myers longest common subsequence algorithm (this matcher is the default for git-diff).
  * An implementation of the edit script generation algorithm of Chawathe et al. (1996). When this algorithm terminates, it will have transformed the "base" AST into one that is isomorphic to the "diff" AST. It will also have transformed the partial mapping left by the matcher into a total mapping between the new base AST and the original diff AST. (T_1 and T_2 in the paper).
  * Code to draw the result the final mapping left by the action script generator.
  * Command line options to draw the new GraphViz output, choose a matcher and list the available matchers, i.e.:

```bash
$ rstreediff -h

Usage: rstreediff [options] <base-file> <diff-file>
       rstreediff [options] <base-file> <diff-file> -d <file> ...
       rstreediff (--help | --list | --version)

Diff two input files.

Options:
    -a, --ast           print AST of input files to STDOUT.
    --debug LEVEL       debug level used by logger. Valid (case sensitive)
                        values are: Debug, Error, Info, Trace, Warn.
    -d, --dot <file>    write out GraphViz representations of the input file(s).
    --edit <file>       write a GraphViz representation of the mapping store to
                        file, after the edit script has been generated.
    -h, --help          print this help menu and exit.
    -l, --list          print information about the available matchers and exit.
    --map <file>        write out GraphViz representation of the mapping store.
    -m, --matcher ALGO  use a given matching algorithm. Valid (case sensitive)
                        values for ALGO are: GumTree (default), Myers.
    --max-size VAL      consider subtrees for matching only if they have a size
                        less than VAL. GumTree only.
    --min-dice VAL      set the similarity threshold used for matching ASTs.
                        Two trees are mapped if they are mappable and have a
                        dice coefficient greater than VAL in [0, 1] (default:
                        0.3). GumTree only.
    --min-height VAL    match only nodes with a height greater than VAL
                        (default: 2). GumTree only.
    -v, --version       print version information and exit.

$ rstreediff --list 

Myers:
-----
This matcher finds the longest common subsequence between two ASTs. Myers is the
default algorithm used by git-diff.

For more information see Myers (1986) An O(ND) Difference Algorithm and its
Variations.

GumTree
-------
This matcher finds implements the GumTree algorithm, which takes account of MOVE
operations between ASTs.

The GumTree algorithm can be configured with the --min-dice, --max-size and
--min-height switches. See --help for more details.

For more information see Falleri et al. (2014) Find-Grained and Accurate Source
Code Differencing.
```

For example, on these two files:

```bash
$ cat tests/add.calc 
1+2

$ cat tests/mult.calc
3*1+2

$
```

The original mapping from the Myers matcher is:

```bash
$ rstreediff --map map.dot --edit edit.dot -m Myers tests/add.calc tests/mult.calc
```

![add_mult_map](https://cloud.githubusercontent.com/assets/97674/26579348/43d0a9fc-452b-11e7-95b2-f4f8eb2c3dd8.png)

And the mapping left by the edit script (new mappings drawn in purple) is:

![add_mult_edit](https://cloud.githubusercontent.com/assets/97674/26579319/2fbf3ffa-452b-11e7-98f7-b64de57aaf1e.png)

The other way around, i.e.:

```bash
$ rstreediff --map map.dot --edit edit.dot -m Myers tests/mult.calc tests/add.calc 
```
is (note grey nodes are unmapped):
![mult_add_map](https://cloud.githubusercontent.com/assets/97674/26579248/eca168c4-452a-11e7-829d-3dcffa6cc538.png)

and the final mapping:
![mult_add_edit](https://cloud.githubusercontent.com/assets/97674/26579256/f5fc45ec-452a-11e7-84f6-18c48ed09b9d.png)
