### PR TITLE
If a grammar cannot be found, fall back to plain text parser.

### DIFF
--- a/grammars/txt.y
+++ b/grammars/txt.y
@@ -1,4 +1,4 @@
 %start document
 %%
 document : paragraph "END" | paragraph "END" document;
-paragraph : "WORD" | "WORD" "SPACE" paragraph;
+paragraph : "WORD" | "WORD" "SPACE" paragraph | "SPACE" paragraph;

--- a/tests/test_ast.rs
+++ b/tests/test_ast.rs
@@ -40,17 +40,30 @@
 
 extern crate treediff;
 
+use std::path::Path;
+
 use treediff::ast::parse_file;
 
-fn compare_ast_dump_to_lrpar_output(filepath: &str, expected: &str) {
-    let arena = parse_file(filepath).unwrap();
+fn compare_ast_dump_to_lrpar_output(is_java: bool, filepath: &str, expected: &str) {
+    let lex = if is_java {
+        Path::new("grammars/java.l")
+    } else {
+        Path::new("grammars/calc.l")
+    };
+    let yacc = if is_java {
+        Path::new("grammars/java.y")
+    } else {
+        Path::new("grammars/calc.y")
+    };
+    let arena = parse_file(filepath, lex, yacc).unwrap();
     let arena_pretty_printed = format!("{:}", arena);
     assert_eq!(expected, arena_pretty_printed);
 }
 
 #[test]
 fn test_empty_calc() {
-    compare_ast_dump_to_lrpar_output("tests/empty.calc",
+    compare_ast_dump_to_lrpar_output(false,
+                                     "tests/empty.calc",
                                      "Expr
  Term
   Factor
@@ -59,7 +72,8 @@ fn test_empty_calc() {
 
 #[test]
 fn test_one_calc() {
-    compare_ast_dump_to_lrpar_output("tests/one.calc",
+    compare_ast_dump_to_lrpar_output(false,
+                                     "tests/one.calc",
                                      "Expr
  Term
   Factor
@@ -69,7 +83,8 @@ fn test_one_calc() {
 
 #[test]
 fn test_add_calc() {
-    compare_ast_dump_to_lrpar_output("tests/add.calc",
+    compare_ast_dump_to_lrpar_output(false,
+                                     "tests/add.calc",
                                      "Expr
  Term
   Factor
@@ -84,7 +99,8 @@ fn test_add_calc() {
 
 #[test]
 fn test_mult_calc() {
-    compare_ast_dump_to_lrpar_output("tests/mult.calc",
+    compare_ast_dump_to_lrpar_output(false,
+                                     "tests/mult.calc",
                                      "Expr
  Term
   Factor
@@ -103,7 +119,8 @@ fn test_mult_calc() {
 
 #[test]
 fn test_hello_java() {
-    compare_ast_dump_to_lrpar_output("tests/Hello.java",
+    compare_ast_dump_to_lrpar_output(true,
+                                     "tests/Hello.java",
                                      "goal
  compilation_unit
   package_declaration_opt

--- a/tests/test_hqueue.rs
+++ b/tests/test_hqueue.rs
@@ -42,6 +42,8 @@
 
 extern crate treediff;
 
+use std::path::Path;
+
 use treediff::ast::{Arena, NodeId, parse_file};
 use treediff::hqueue::HeightQueue;
 
@@ -71,33 +73,43 @@ fn assert_sorted<T: Clone>(queue: &HeightQueue, arena: &Arena<T>) {
     assert_eq!(0, expected);
 }
 
-fn assert_sorted_from_file(filepath: &str) {
-    let arena = parse_file(filepath).unwrap();
+fn assert_sorted_from_file(is_java: bool, filepath: &str) {
+    let lex = if is_java {
+        Path::new("grammars/java.l")
+    } else {
+        Path::new("grammars/calc.l")
+    };
+    let yacc = if is_java {
+        Path::new("grammars/java.y")
+    } else {
+        Path::new("grammars/calc.y")
+    };
+    let arena = parse_file(filepath, lex, yacc).unwrap();
     let queue = arena.get_priority_queue();
     assert_sorted(&queue, &arena);
 }
 
 #[test]
 fn test_empty_calc() {
-    assert_sorted_from_file("tests/empty.calc");
+    assert_sorted_from_file(false, "tests/empty.calc");
 }
 
 #[test]
 fn test_one_calc() {
-    assert_sorted_from_file("tests/one.calc");
+    assert_sorted_from_file(false, "tests/one.calc");
 }
 
 #[test]
 fn test_add_calc() {
-    assert_sorted_from_file("tests/add.calc");
+    assert_sorted_from_file(false, "tests/add.calc");
 }
 
 #[test]
 fn test_mult_calc() {
-    assert_sorted_from_file("tests/mult.calc");
+    assert_sorted_from_file(false, "tests/mult.calc");
 }
 
 #[test]
 fn test_hello_java() {
-    assert_sorted_from_file("tests/Hello.java");
+    assert_sorted_from_file(true, "tests/Hello.java");
 }


### PR DESCRIPTION
The intention here is to enable the user to diff files for which we don't yet have a grammar.