### PR TITLE
Third infrastructure PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "lrpar 0.1.0 (git+http://github.com/softdevteam/lrpar)",
  "lrtable 0.1.0 (git+http://github.com/softdevteam/lrtable)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -213,6 +214,15 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "term"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread-id"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d168af3930b369cfe245132550579d47dfd873d69470755a19c2c6568dbbd989"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8df7875b676fddfadffd96deea3b1124e5ede707d4884248931077518cf1f773"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ env_logger = "0.4.2"
 docopt = "0.7.0"
 log = "0.3.7"
 rustc-serialize = "0.3"
+term = "0.4.5"
 lrlex = { git = "http://github.com/softdevteam/lrlex" }
 lrpar = { git = "http://github.com/softdevteam/lrpar" }
 lrtable = { git = "http://github.com/softdevteam/lrtable" }

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -233,7 +233,12 @@ impl<T: Clone + Display> ApplyAction<T> for Delete {
 
 impl<T: Clone + Display> ApplyAction<T> for Insert<T> {
     fn apply(&mut self, arena: &mut Arena<T>) -> ArenaResult {
-        let mut new_id = arena.new_node(self.value.clone(), self.label.clone(), self.indent);
+        // Set line no, char no, token length to `None`.
+        let mut new_id = arena.new_node(self.value.clone(),
+                                        self.label.clone(),
+                                        self.indent,
+                                        None,
+                                        None);
         new_id.make_nth_child_of(self.new_parent, self.nth_child, arena)
     }
 }
@@ -324,14 +329,14 @@ mod test {
 
     fn create_arena() -> Arena<String> {
         let mut arena = Arena::new();
-        let root = arena.new_node(String::from("+"), String::from("Expr"), 0);
-        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2);
+        let root = arena.new_node(String::from("+"), String::from("Expr"), 0, None, None);
+        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2, None, None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2);
+        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2, None, None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4);
+        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4, None, None);
         n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4);
+        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4, None, None);
         n4.make_child_of(n2, &mut arena).unwrap();
         arena
     }

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -44,6 +44,21 @@ use std::fmt::{Formatter, Display, Result};
 use ast::{Arena, ArenaError, ArenaResult, NodeId};
 use emitters::RenderJson;
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+/// Type of action.
+///
+/// Only used where the information related to actions can safely be discarded.
+pub enum ActionType {
+    /// Delete a node in a 'from' arena.
+    DELETE,
+    /// Insert a new node into the 'from' arena.
+    INSERT,
+    /// Move an existing node.
+    MOVE,
+    /// Update the text or label associated with a node.
+    UPDATE,
+}
+
 /// Apply an action to an AST node.
 pub trait ApplyAction<T: Clone + Display>: Display + RenderJson {
     /// Apply an action to an AST.

--- a/src/lib/hqueue.rs
+++ b/src/lib/hqueue.rs
@@ -184,14 +184,14 @@ mod tests {
 
     fn create_arena() -> Arena<String> {
         let mut arena = Arena::new();
-        let root = arena.new_node(String::from("+"), String::from("Expr"), 0);
-        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2);
+        let root = arena.new_node(String::from("+"), String::from("Expr"), 0, None, None);
+        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2, None, None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2);
+        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2, None, None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4);
+        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4, None, None);
         n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4);
+        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4, None, None);
         n4.make_child_of(n2, &mut arena).unwrap();
         let format1 = "Expr +
   INT 1
@@ -332,7 +332,7 @@ mod tests {
     fn bench_push(bencher: &mut Bencher) {
         let mut arena: Arena<String> = Arena::new();
         for _ in 0..BENCH_ITER {
-            arena.new_node(String::from(""), String::from(""), 0);
+            arena.new_node(String::from(""), String::from(""), 0, None, None);
         }
         let mut queue = HeightQueue::new();
         // Because `HeightQueues` are sets, each iteration of this

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -579,14 +579,14 @@ mod tests {
 
     fn create_mult_arena() -> Arena<String> {
         let mut arena = Arena::new();
-        let root = arena.new_node(String::from("+"), String::from("Expr"), 0);
-        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2);
+        let root = arena.new_node(String::from("+"), String::from("Expr"), 0, None, None);
+        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2, None, None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2);
+        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2, None, None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4);
+        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4, None, None);
         n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4);
+        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4, None, None);
         n4.make_child_of(n2, &mut arena).unwrap();
         let format1 = "Expr +
   INT 1
@@ -600,10 +600,10 @@ mod tests {
 
     fn create_plus_arena() -> Arena<String> {
         let mut arena = Arena::new();
-        let root = arena.new_node(String::from("+"), String::from("Expr"), 0);
-        let n1 = arena.new_node(String::from("3"), String::from("INT"), 4);
+        let root = arena.new_node(String::from("+"), String::from("Expr"), 0, None, None);
+        let n1 = arena.new_node(String::from("3"), String::from("INT"), 4, None, None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node(String::from("4"), String::from("INT"), 4);
+        let n2 = arena.new_node(String::from("4"), String::from("INT"), 4, None, None);
         n2.make_child_of(root, &mut arena).unwrap();
         let format1 = "Expr +
     INT 3

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -73,5 +73,10 @@ pub mod myers_matcher;
 /// A queue of `NodeId`s sorted on the height of their respective nodes.
 pub mod hqueue;
 
+/// A patch represents a diff on a single AST node.
+///
+/// Also deals with turning nearby patches into hunks.
+pub mod patch;
+
 /// Algorithms which act on sequences of values.
 pub mod sequence;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -45,6 +45,7 @@ extern crate log;
 extern crate lrlex;
 extern crate lrtable;
 extern crate lrpar;
+extern crate term;
 extern crate test;
 
 /// Actions are operations that transform abstract syntax trees.

--- a/src/lib/patch.rs
+++ b/src/lib/patch.rs
@@ -1,0 +1,262 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a “Larger Work” to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#![warn(missing_docs)]
+
+use std::clone::Clone;
+use std::collections::BTreeMap;
+
+use action::ActionType;
+
+// How close do two diffs have to be (in characters) to be merged into one patch?
+// We assume lines are 80 characters long.
+const DIST_THRESHOLD: u64 = 3 * 80;
+
+#[derive(Clone, Eq, Debug, PartialEq)]
+/// A patch represents a single change in the input files.
+///
+/// See the `Hunk` struct which aggregates a number of related patches.
+pub struct Patch {
+    action: ActionType,
+    start: usize,
+    length: usize,
+}
+
+impl Patch {
+    /// Create a new patch.
+    pub fn new(ty: ActionType, start: usize, length: usize) -> Patch {
+        Patch {
+            action: ty,
+            start: start,
+            length: length,
+        }
+    }
+
+    /// Character number where this patch begins in the original file.
+    ///
+    /// The lexeme affected by this patch lies in the interval `[start, end)`,
+    /// as a convenience for printing slices from the original file, i.e.
+    /// `println!("{}", &file[patch.start()..patch.end()])`.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Character number where this patch ends in the original file.
+    ///
+    /// The lexeme affected by this patch lies in the interval `[start, end)`,
+    /// as a convenience for printing slices from the original file, i.e.
+    /// `println!("{}", &file[patch.start()..patch.end()])`.
+    pub fn end(&self) -> usize {
+        self.start + self.length
+    }
+
+    /// Action associated with this patch.
+    pub fn action(&self) -> &ActionType {
+        &self.action
+    }
+}
+
+#[derive(Clone, Eq, Debug, PartialEq)]
+/// A hunk is a group of patches close to one another in the original files.
+///
+/// Patches inside a hunk are not necessarily contiguous.
+pub struct Hunk {
+    patches: Vec<Patch>,
+    start: usize,
+    length: usize,
+}
+
+impl Hunk {
+    /// Convert a patch into a hunk.
+    pub fn new(patch: Patch) -> Hunk {
+        Hunk {
+            patches: vec![patch.clone()],
+            start: patch.start,
+            length: patch.length,
+        }
+    }
+
+    fn end(&self) -> usize {
+        self.start + self.length
+    }
+
+    fn add_patch(&mut self, patch: Patch) {
+        if patch.start < self.start {
+            self.start = patch.start;
+        }
+        let p_end = patch.end();
+        if p_end > self.end() {
+            self.length += p_end - self.end();
+        }
+        self.patches.push(patch);
+    }
+
+    fn is_patch_related(&self, patch: &Patch) -> bool {
+        (self.start as i64 - patch.start as i64).abs() <= DIST_THRESHOLD as i64
+    }
+
+    /// Given a character number, return type and length of any patches that
+    /// the character is involved in.
+    ///
+    /// The return value is the action type and the number of characters from
+    /// `ch` that are involved in that patch.
+    pub fn get_action(&self, ch: usize) -> Option<(ActionType, usize)> {
+        if ch >= self.start && ch < self.end() {
+            for patch in &self.patches {
+                if ch >= patch.start && ch < patch.end() {
+                    return Some((patch.action.clone(), patch.end() - ch));
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Get the header for this hunk, in diff format.
+pub fn header(from: &Hunk, to: &Hunk) -> String {
+    format!("@@ -{},{} +{},{} @@",
+            from.start,
+            from.length,
+            to.start,
+            to.length)
+}
+
+/// Group related patches into hunks.
+pub fn hunkify(patches: Vec<Patch>) -> BTreeMap<(usize, usize), Hunk> {
+    let mut hunks: Vec<Hunk> = vec![];
+    for patch in patches {
+        let mut added = false;
+        for hunk in &mut hunks {
+            if hunk.is_patch_related(&patch) {
+                hunk.add_patch(patch.clone());
+                added = true;
+                break;
+            }
+        }
+        if !added {
+            hunks.push(Hunk::new(patch.clone()));
+        }
+    }
+    // TODO: Could also merge nearby hunks.
+    let mut map = BTreeMap::new();
+    for hunk in hunks {
+        map.insert((hunk.start, hunk.start + hunk.length), hunk);
+    }
+    map
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_patch() {
+        let p = Patch::new(ActionType::DELETE, 27, 6);
+        assert_eq!(&ActionType::DELETE, p.action());
+        assert_eq!(27, p.start());
+        assert_eq!(33, p.end());
+    }
+
+    #[test]
+    fn test_get_action() {
+        let p0 = Patch::new(ActionType::DELETE, 0, 6);
+        let p1 = Patch::new(ActionType::UPDATE, 7, 6);
+        let mut hunk = Hunk::new(p0);
+        let p2 = Patch::new(ActionType::MOVE, 20, 6);
+        let p3 = Patch::new(ActionType::INSERT, 27, 10);
+        hunk.add_patch(p1.clone());
+        hunk.add_patch(p2.clone());
+        hunk.add_patch(p3.clone());
+        for i in 0..6 {
+            assert_eq!(Some((ActionType::DELETE, 6 - i)), hunk.get_action(i));
+        }
+        assert_eq!(None, hunk.get_action(6));
+        for i in 7..13 {
+            assert_eq!(Some((ActionType::UPDATE, 13 - i)), hunk.get_action(i));
+        }
+        for i in 13..20 {
+            assert_eq!(None, hunk.get_action(i));
+        }
+        for i in 20..26 {
+            assert_eq!(Some((ActionType::MOVE, 26 - i)), hunk.get_action(i));
+        }
+        assert_eq!(None, hunk.get_action(26));
+        for i in 27..37 {
+            assert_eq!(Some((ActionType::INSERT, 37 - i)), hunk.get_action(i));
+        }
+        assert_eq!(None, hunk.get_action(37));
+    }
+
+    #[test]
+    fn test_is_close() {
+        let p0 = Patch::new(ActionType::DELETE, 0, 6);
+        let p1 = Patch::new(ActionType::UPDATE, 7, 6);
+        let p2 = Patch::new(ActionType::MOVE, 20, 6);
+        let p3 = Patch::new(ActionType::INSERT, 507, 10);
+        let hunk = Hunk::new(p0);
+        assert!(hunk.is_patch_related(&p1));
+        assert!(hunk.is_patch_related(&p2));
+        assert!(!hunk.is_patch_related(&p3));
+    }
+
+    #[test]
+    fn test_hunkify() {
+        let patches = vec![Patch::new(ActionType::DELETE, 0, 6),
+                           Patch::new(ActionType::UPDATE, 7, 6),
+                           Patch::new(ActionType::MOVE, 20, 6),
+                           Patch::new(ActionType::INSERT, 507, 10)];
+
+        let hunks = hunkify(patches);
+        assert_eq!(2, hunks.len());
+        assert!(hunks.contains_key(&(0, 26)));
+        assert!(hunks.contains_key(&(507, 517)));
+    }
+
+    #[test]
+    fn test_header() {
+        let p0 = Patch::new(ActionType::DELETE, 0, 6);
+        let p1 = Patch::new(ActionType::UPDATE, 7, 6);
+        let mut hunk_from = Hunk::new(p0);
+        hunk_from.add_patch(p1);
+        let p2 = Patch::new(ActionType::MOVE, 20, 6);
+        let p3 = Patch::new(ActionType::INSERT, 27, 10);
+        let mut hunk_to = Hunk::new(p2);
+        hunk_to.add_patch(p3);
+        assert_eq!(String::from("@@ -0,13 +20,17 @@"),
+                   header(&hunk_from, &hunk_to));
+    }
+}

--- a/src/lib/sequence.rs
+++ b/src/lib/sequence.rs
@@ -123,18 +123,18 @@ mod tests {
         let mut base_arena: Arena<T> = Arena::new();
         let mut id: NodeId;
         if !base.is_empty() {
-            let root = base_arena.new_node(Default::default(), String::from("NULL"), 0);
+            let root = base_arena.new_node(Default::default(), String::from("NULL"), 0, None, None);
             for value in base {
-                id = base_arena.new_node(value.clone(), String::from("T"), 0);
+                id = base_arena.new_node(value.clone(), String::from("T"), 0, None, None);
                 id.make_child_of(root, &mut base_arena).unwrap();
 
             }
         }
         let mut diff_arena: Arena<T> = Arena::new();
         if !diff.is_empty() {
-            let root = diff_arena.new_node(Default::default(), String::from("NULL"), 0);
+            let root = diff_arena.new_node(Default::default(), String::from("NULL"), 0, None, None);
             for value in diff {
-                id = diff_arena.new_node(value.clone(), String::from("T"), 0);
+                id = diff_arena.new_node(value.clone(), String::from("T"), 0, None, None);
                 id.make_child_of(root, &mut diff_arena).unwrap();
             }
         }


### PR DESCRIPTION
This is the third PR to introduce significant new infrastructure, and it will be the last for a while.

This PR introduces coloured diffs on the terminal. At this point, even though the test cases in the repo are very small (in terms of file size) the size of the resulting parse trees is such that the graphviz output and debug output is often too large to look through in detail, this PR is intended to make debugging a little easier.

Because this feature is needed for debugging, the implementation has several deficiencies:

  * Producing a diff is not especially efficient in either time or space.
  * The output cannot be used to produce a patch.
  * Some systems post-process diff output to make it either more accurate or more readable, this implementation does not. Inevitably the output will sometimes be difficult to read.
  * The whole file is printed, rather than just the "context" of the diff.

The colour key is:

  * Deletions -- RED
  * Insertions -- GREEN
  * Updates -- YELLOW
  * Moves -- BLUE (the origin of the move is marked with a circumflex)

## Examples

This is the GT "webdiff" output of the example from the GT paper:

![gt_side_by_side](https://cloud.githubusercontent.com/assets/97674/26745215/6bbf566c-47e1-11e7-96a2-b577dc061b7a.png)

and this is the same output in rstreediff (using the Myers matcher):

![java1](https://cloud.githubusercontent.com/assets/97674/26745361/0e117030-47e2-11e7-9fe4-f63e888e8668.png)

Swapping the order of the files:

![java2](https://cloud.githubusercontent.com/assets/97674/26745413/472d4fba-47e2-11e7-84ad-bd9620f92d3d.png)

Some calc files:

![calc](https://cloud.githubusercontent.com/assets/97674/26745419/51fc3f50-47e2-11e7-9f17-80ae33aa6064.png)
