### PR TITLE
Simplify action by relaxing trait bounds.

### DIFF
--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -39,7 +39,7 @@
 
 use std::borrow::Cow::Owned;
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::Display;
+use std::fmt::Debug;
 use std::fs::File;
 use std::io::{Error, Read, Write};
 
@@ -125,11 +125,11 @@ fn read_file(path: &str) -> Result<String, EmitterError> {
 /// If the terminal foreground cannot be changed or reset by the
 /// [term](https://crates.io/crates/term) crate, this function will panic.
 /// However, `term` is cross-platform so this failure case should be rare.
-pub fn write_diff_to_stdout<T: Clone + Display + Eq>(store: &MappingStore<T>,
-                                                     script: &EditScript<T>,
-                                                     from_path: &str,
-                                                     to_path: &str)
-                                                     -> Result<(), EmitterError> {
+pub fn write_diff_to_stdout<T: Clone + Debug + Eq>(store: &MappingStore<T>,
+                                                   script: &EditScript<T>,
+                                                   from_path: &str,
+                                                   to_path: &str)
+                                                   -> Result<(), EmitterError> {
     let colours = build_colour_map();
     // Turn edit script and mappings into hunks of related patches.
     let mut from_patches: Vec<Patch> = vec![];

--- a/src/lib/gt_matcher.rs
+++ b/src/lib/gt_matcher.rs
@@ -37,7 +37,7 @@
 
 #![warn(missing_docs)]
 
-use std::fmt::Display;
+use std::fmt::Debug;
 
 use ast::{Arena, NodeId};
 use matchers::{MappingStore, MappingType, MatchTrees};
@@ -72,7 +72,7 @@ impl GumTreeConfig {
     }
 }
 
-impl<T: Clone + Display + Eq + 'static> MatchTrees<T> for GumTreeConfig {
+impl<T: Clone + Debug + Eq + 'static> MatchTrees<T> for GumTreeConfig {
     /// Describe this matcher for the user.
     fn describe(&self) -> String {
         let desc = "

--- a/src/lib/myers_matcher.rs
+++ b/src/lib/myers_matcher.rs
@@ -37,7 +37,7 @@
 
 #![warn(missing_docs)]
 
-use std::fmt::Display;
+use std::fmt::Debug;
 
 use ast::{Arena, NodeId};
 use matchers::{MappingStore, MappingType, MatchTrees};
@@ -60,7 +60,7 @@ impl MyersConfig {
     }
 }
 
-impl<T: Clone + Display + Eq + 'static> MatchTrees<T> for MyersConfig {
+impl<T: Clone + Debug + Eq + 'static> MatchTrees<T> for MyersConfig {
     /// Describe this matcher for the user.
     fn describe(&self) -> String {
         let desc = "
@@ -98,10 +98,10 @@ Variations.";
 }
 
 /// Test that two nodes have the same label and value.
-fn eq<T: Clone + Display + Eq>(n1: &NodeId,
-                               arena1: &Arena<T>,
-                               n2: &NodeId,
-                               arena2: &Arena<T>)
-                               -> bool {
+fn eq<T: Clone + Debug + Eq>(n1: &NodeId,
+                             arena1: &Arena<T>,
+                             n2: &NodeId,
+                             arena2: &Arena<T>)
+                             -> bool {
     arena1[*n1].label == arena2[*n2].label && arena1[*n1].value == arena2[*n2].value
 }

--- a/src/lib/sequence.rs
+++ b/src/lib/sequence.rs
@@ -91,7 +91,7 @@ pub fn lcss<T: Clone + Eq>(seq1: &[NodeId],
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fmt::{Debug, Display};
+    use std::fmt::Debug;
     use matchers::MappingStore;
 
     fn eq<T: Clone + Debug + Eq>(n1: &NodeId,
@@ -117,9 +117,9 @@ mod tests {
         }
     }
 
-    fn create_mapping_store<T: Clone + Default + Display + Eq + 'static>(base: &[T],
-                                                                         diff: &[T])
-                                                                         -> MappingStore<T> {
+    fn create_mapping_store<T: Clone + Default + Debug + Eq + 'static>(base: &[T],
+                                                                       diff: &[T])
+                                                                       -> MappingStore<T> {
         let mut base_arena: Arena<T> = Arena::new();
         let mut id: NodeId;
         if !base.is_empty() {


### PR DESCRIPTION
This PR:

  * Removes the requirement for the type variable T to implement the `Display` trait
  * Removes the implementation of `Display` for the types in `action.rs` -- these are not needed by the edit script generator