### PR TITLE
Update dependency APIs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "rstreediff"
 version = "0.1.0"
 dependencies = [
+ "cfgrammar 0.1.0 (git+https://github.com/softdevteam/cfgrammar)",
  "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dot 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -31,13 +32,20 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "custom_derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+name = "cfgrammar"
+version = "0.1.0"
+source = "git+https://github.com/softdevteam/cfgrammar#d6cff902bedfebcf0753d51e95f5e13bcf3d8846"
+dependencies = [
+ "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "macro-attr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "docopt"
@@ -101,7 +109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "lrlex"
 version = "0.1.0"
-source = "git+http://github.com/softdevteam/lrlex#16a8a756bea89c685f960f7eec7d2c6e957bcd9b"
+source = "git+http://github.com/softdevteam/lrlex#47a42d5286d2d8ef8f5bdda2913fdc00ba941822"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -111,8 +119,9 @@ dependencies = [
 [[package]]
 name = "lrpar"
 version = "0.1.0"
-source = "git+http://github.com/softdevteam/lrpar#5fb7917db373125422ed638eee2732c9357e9da1"
+source = "git+http://github.com/softdevteam/lrpar#ee09e7f1504b03833e3180daa6c75d9164e1197d"
 dependencies = [
+ "cfgrammar 0.1.0 (git+https://github.com/softdevteam/cfgrammar)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "lrlex 0.1.0 (git+http://github.com/softdevteam/lrlex)",
  "lrtable 0.1.0 (git+http://github.com/softdevteam/lrtable)",
@@ -121,16 +130,21 @@ dependencies = [
 [[package]]
 name = "lrtable"
 version = "0.1.0"
-source = "git+http://github.com/softdevteam/lrtable#4b7f0e89215b0d117b74e56eb9662851ee326d15"
+source = "git+http://github.com/softdevteam/lrtable#16a5f4be25f6ff4e8237dc6eceb5fe160afa2e51"
 dependencies = [
- "bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfgrammar 0.1.0 (git+https://github.com/softdevteam/cfgrammar)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "macro-attr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "macro-attr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
@@ -293,8 +307,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
-"checksum bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b97c2c8e8bbb4251754f559df8af22fb264853c7d009084a576cdf12565089d"
-"checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+"checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+"checksum cfgrammar 0.1.0 (git+https://github.com/softdevteam/cfgrammar)" = "<none>"
 "checksum docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab32ea6e284d87987066f21a9e809a73c14720571ef34516f0890b3d355ccfd8"
 "checksum dot 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6bad61973e929901dfd6f78054501325546c979692543150055e77e52191a0eb"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
@@ -307,6 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lrlex 0.1.0 (git+http://github.com/softdevteam/lrlex)" = "<none>"
 "checksum lrpar 0.1.0 (git+http://github.com/softdevteam/lrpar)" = "<none>"
 "checksum lrtable 0.1.0 (git+http://github.com/softdevteam/lrtable)" = "<none>"
+"checksum macro-attr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00e51c6f0e2bf862b01b3d784fc32b02feb248a69062c51fb0b6d14cd526cc2a"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ docopt = "0.7.0"
 log = "0.3.7"
 rustc-serialize = "0.3"
 term = "0.4.5"
+cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
 lrlex = { git = "http://github.com/softdevteam/lrlex" }
 lrpar = { git = "http://github.com/softdevteam/lrpar" }
 lrtable = { git = "http://github.com/softdevteam/lrtable" }

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -46,9 +46,11 @@ use std::io::Read;
 use std::ops::{Index, IndexMut};
 use std::path::Path;
 
+use cfgrammar::TIdx;
+use cfgrammar::yacc::YaccGrammar;
 use lrlex::{build_lex, Lexeme};
 use lrpar::parser;
-use lrtable::{Grammar, Minimiser, TIdx, yacc_to_statetable};
+use lrtable::{Minimiser, yacc_to_statetable};
 
 use hqueue::HeightQueue;
 
@@ -645,7 +647,7 @@ impl<'a, T: Clone> Iterator for PreOrderTraversal<'a, T> {
 }
 
 // Turn a grammar, parser and input string into an AST arena.
-fn parse_into_ast(pt: &parser::Node<u16>, grm: &Grammar, input: &str) -> Arena<String> {
+fn parse_into_ast(pt: &parser::Node<u16>, grm: &YaccGrammar, input: &str) -> Arena<String> {
     let mut arena = Arena::new();
     let mut st = vec![(0, pt)]; // Stack of (indent level, node) pairs
     // Stack of `Option<NodeId>`s which are parents of nodes on the `st` stack.
@@ -756,7 +758,7 @@ pub fn parse_file(input_path: &str,
         Ok(tokens) => tokens,
         Err(_) => return Err(ParseError::LexicalError),
     };
-    lexemes.push(Lexeme::new(u16::try_from(usize::from(grm.end_term)).unwrap(),
+    lexemes.push(Lexeme::new(u16::try_from(usize::from(grm.end_term_idx())).unwrap(),
                              input.len(),
                              0));
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -38,6 +38,7 @@
 #![feature(test)]
 #![feature(try_from)]
 
+extern crate cfgrammar;
 extern crate dot;
 extern crate env_logger;
 #[macro_use]


### PR DESCRIPTION
This PR updates rstreediff to use the new `cfgrammar` API.