### PR TITLE
Add line and column numbers to AST nodes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "lrlex"
 version = "0.1.0"
-source = "git+http://github.com/softdevteam/lrlex#47a42d5286d2d8ef8f5bdda2913fdc00ba941822"
+source = "git+http://github.com/softdevteam/lrlex#0b8c91d3a195b093a33a902df6a30a33999a5cf4"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -119,7 +119,7 @@ dependencies = [
 [[package]]
 name = "lrpar"
 version = "0.1.0"
-source = "git+http://github.com/softdevteam/lrpar#ee09e7f1504b03833e3180daa6c75d9164e1197d"
+source = "git+http://github.com/softdevteam/lrpar#0e8a86ec50022fd0250c75fb95941478b7f8b96b"
 dependencies = [
  "cfgrammar 0.1.0 (git+https://github.com/softdevteam/cfgrammar)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -365,14 +365,44 @@ mod test {
 
     fn create_arena() -> Arena<String> {
         let mut arena = Arena::new();
-        let root = arena.new_node(String::from("+"), String::from("Expr"), 0, None, None);
-        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2, None, None);
+        let root = arena.new_node(String::from("+"),
+                                  String::from("Expr"),
+                                  0,
+                                  None,
+                                  None,
+                                  None,
+                                  None);
+        let n1 = arena.new_node(String::from("1"),
+                                String::from("INT"),
+                                2,
+                                None,
+                                None,
+                                None,
+                                None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2, None, None);
+        let n2 = arena.new_node(String::from("*"),
+                                String::from("Expr"),
+                                2,
+                                None,
+                                None,
+                                None,
+                                None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4, None, None);
+        let n3 = arena.new_node(String::from("3"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4, None, None);
+        let n4 = arena.new_node(String::from("4"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         n4.make_child_of(n2, &mut arena).unwrap();
         arena
     }
@@ -416,7 +446,13 @@ mod test {
     #[test]
     fn apply_insert() {
         let mut arena = create_arena();
-        let n5 = arena.new_node(String::from("100"), String::from("INT"), 4, None, None);
+        let n5 = arena.new_node(String::from("100"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         let format1 = "Expr +
   INT 1
   Expr *
@@ -488,8 +524,20 @@ mod test {
     INT 3
     INT 4
 ";
-        let n5 = arena.new_node(String::from("100"), String::from("INT"), 4, None, None);
-        let n6 = arena.new_node(String::from("99"), String::from("INT"), 4, None, None);
+        let n5 = arena.new_node(String::from("100"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
+        let n6 = arena.new_node(String::from("99"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         assert_eq!(format1, format!("{}", arena));
         // Create action list.
         let mut actions: EditScript<String> = EditScript::new();
@@ -527,7 +575,13 @@ mod test {
     INT 4
 ";
         assert_eq!(format1, format!("{}", arena));
-        let n5 = arena.new_node(String::from("2"), String::from("INT"), 4, None, None);
+        let n5 = arena.new_node(String::from("2"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         // Create action list.
         let mut actions: EditScript<String> = EditScript::new();
         let del = Delete { node: NodeId::new(4) }; // Remove "4".

--- a/src/lib/hqueue.rs
+++ b/src/lib/hqueue.rs
@@ -184,14 +184,44 @@ mod tests {
 
     fn create_arena() -> Arena<String> {
         let mut arena = Arena::new();
-        let root = arena.new_node(String::from("+"), String::from("Expr"), 0, None, None);
-        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2, None, None);
+        let root = arena.new_node(String::from("+"),
+                                  String::from("Expr"),
+                                  0,
+                                  None,
+                                  None,
+                                  None,
+                                  None);
+        let n1 = arena.new_node(String::from("1"),
+                                String::from("INT"),
+                                2,
+                                None,
+                                None,
+                                None,
+                                None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2, None, None);
+        let n2 = arena.new_node(String::from("*"),
+                                String::from("Expr"),
+                                2,
+                                None,
+                                None,
+                                None,
+                                None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4, None, None);
+        let n3 = arena.new_node(String::from("3"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4, None, None);
+        let n4 = arena.new_node(String::from("4"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         n4.make_child_of(n2, &mut arena).unwrap();
         let format1 = "Expr +
   INT 1
@@ -332,7 +362,13 @@ mod tests {
     fn bench_push(bencher: &mut Bencher) {
         let mut arena: Arena<String> = Arena::new();
         for _ in 0..BENCH_ITER {
-            arena.new_node(String::from(""), String::from(""), 0, None, None);
+            arena.new_node(String::from(""),
+                           String::from(""),
+                           0,
+                           None,
+                           None,
+                           None,
+                           None);
         }
         let mut queue = HeightQueue::new();
         // Because `HeightQueues` are sets, each iteration of this

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -352,6 +352,8 @@ impl<T: Clone + Debug + Eq + 'static> MappingStore<T> {
                 w = self.from_arena.new_node(self.to_arena[x].value.clone(),
                                              self.to_arena[x].label.clone(),
                                              self.to_arena[x].indent,
+                                             self.to_arena[x].col_no,
+                                             self.to_arena[x].line_no,
                                              self.to_arena[x].char_no,
                                              self.to_arena[x].token_len);
                 new_mappings.push(w, x);
@@ -577,14 +579,44 @@ mod tests {
 
     fn create_mult_arena() -> Arena<String> {
         let mut arena = Arena::new();
-        let root = arena.new_node(String::from("+"), String::from("Expr"), 0, None, None);
-        let n1 = arena.new_node(String::from("1"), String::from("INT"), 2, None, None);
+        let root = arena.new_node(String::from("+"),
+                                  String::from("Expr"),
+                                  0,
+                                  None,
+                                  None,
+                                  None,
+                                  None);
+        let n1 = arena.new_node(String::from("1"),
+                                String::from("INT"),
+                                2,
+                                None,
+                                None,
+                                None,
+                                None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node(String::from("*"), String::from("Expr"), 2, None, None);
+        let n2 = arena.new_node(String::from("*"),
+                                String::from("Expr"),
+                                2,
+                                None,
+                                None,
+                                None,
+                                None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node(String::from("3"), String::from("INT"), 4, None, None);
+        let n3 = arena.new_node(String::from("3"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node(String::from("4"), String::from("INT"), 4, None, None);
+        let n4 = arena.new_node(String::from("4"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         n4.make_child_of(n2, &mut arena).unwrap();
         let format1 = "Expr +
   INT 1
@@ -598,10 +630,28 @@ mod tests {
 
     fn create_plus_arena() -> Arena<String> {
         let mut arena = Arena::new();
-        let root = arena.new_node(String::from("+"), String::from("Expr"), 0, None, None);
-        let n1 = arena.new_node(String::from("3"), String::from("INT"), 4, None, None);
+        let root = arena.new_node(String::from("+"),
+                                  String::from("Expr"),
+                                  0,
+                                  None,
+                                  None,
+                                  None,
+                                  None);
+        let n1 = arena.new_node(String::from("3"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node(String::from("4"), String::from("INT"), 4, None, None);
+        let n2 = arena.new_node(String::from("4"),
+                                String::from("INT"),
+                                4,
+                                None,
+                                None,
+                                None,
+                                None);
         n2.make_child_of(root, &mut arena).unwrap();
         let format1 = "Expr +
     INT 3

--- a/src/lib/sequence.rs
+++ b/src/lib/sequence.rs
@@ -174,18 +174,32 @@ mod tests {
         let mut base_arena: Arena<T> = Arena::new();
         let mut id: NodeId;
         if !base.is_empty() {
-            let root = base_arena.new_node(Default::default(), String::from("NULL"), 0, None, None);
+            let root = base_arena.new_node(Default::default(),
+                                           String::from("NULL"),
+                                           0,
+                                           None,
+                                           None,
+                                           None,
+                                           None);
             for value in base {
-                id = base_arena.new_node(value.clone(), String::from("T"), 0, None, None);
+                id = base_arena
+                    .new_node(value.clone(), String::from("T"), 0, None, None, None, None);
                 id.make_child_of(root, &mut base_arena).unwrap();
 
             }
         }
         let mut diff_arena: Arena<T> = Arena::new();
         if !diff.is_empty() {
-            let root = diff_arena.new_node(Default::default(), String::from("NULL"), 0, None, None);
+            let root = diff_arena.new_node(Default::default(),
+                                           String::from("NULL"),
+                                           0,
+                                           None,
+                                           None,
+                                           None,
+                                           None);
             for value in diff {
-                id = diff_arena.new_node(value.clone(), String::from("T"), 0, None, None);
+                id = diff_arena
+                    .new_node(value.clone(), String::from("T"), 0, None, None, None, None);
                 id.make_child_of(root, &mut diff_arena).unwrap();
             }
         }


### PR DESCRIPTION
Currently, line and column numbers are not used, so no behaviour has changed.